### PR TITLE
Allow values to insert to be passed as array of setters

### DIFF
--- a/SQLite Common/Query.swift
+++ b/SQLite Common/Query.swift
@@ -449,7 +449,19 @@ public struct Query {
         return insert([value] + more)
     }
 
-    private func insert(values: [Setter]) -> (ID: Int?, statement: Statement) {
+    /// Runs an INSERT statement against the query.
+    ///
+    /// :param: values An array of values to set.
+    ///
+    /// :returns: The row ID.
+    public func insert(values: [Setter]) -> Int? { return insert(values).ID }
+
+    /// Runs an INSERT statement against the query.
+    ///
+    /// :param: values An array of values to set.
+    ///
+    /// :returns: The row ID and statement.
+    public func insert(values: [Setter]) -> (ID: Int?, statement: Statement) {
         let statement = insertStatement(values).run()
         return (statement.failed ? nil : database.lastID, statement)
     }

--- a/SQLite Common/Query.swift
+++ b/SQLite Common/Query.swift
@@ -508,7 +508,19 @@ public struct Query {
         return replace(values)
     }
 
-    private func replace(values: [Setter]) -> (ID: Int?, statement: Statement) {
+    /// Runs a REPLACE statement against the query.
+    ///
+    /// :param: values An array of values to set.
+    ///
+    /// :returns: The row ID.
+    public func replace(values: [Setter]) -> Int? { return replace(values).ID }
+
+    /// Runs a REPLACE statement against the query.
+    ///
+    /// :param: values An array of values to set.
+    ///
+    /// :returns: The row ID and statement.
+    public func replace(values: [Setter]) -> (ID: Int?, statement: Statement) {
         let statement = insertStatement(values, or: .Replace).run()
         return (statement.failed ? nil : database.lastID, statement)
     }
@@ -536,7 +548,19 @@ public struct Query {
         return update(values)
     }
 
-    private func update(values: [Setter]) -> (changes: Int?, statement: Statement) {
+    /// Runs an UPDATE statement against the query.
+    ///
+    /// :param: values An array of of values to set.
+    ///
+    /// :returns: The number of updated rows.
+    public func update(values: [Setter]) -> Int? { return update(values).changes }
+
+    /// Runs an UPDATE statement against the query.
+    ///
+    /// :param: values An array of of values to set.
+    ///
+    /// :returns: The number of updated rows and statement.
+    public func update(values: [Setter]) -> (changes: Int?, statement: Statement) {
         let statement = updateStatement(values).run()
         return (statement.failed ? nil : database.lastChanges, statement)
     }


### PR DESCRIPTION
Hello!

It can be helpful to build up the setters for a query dynamically. If Swift supported splatting, then the existing `insert` could be used (e.g. `insert(*[name <- "Alice", email <- "alice@mac.com"])`), but it doesn't (https://devforums.apple.com/message/970958).

This diff lets the columns be built up dynamically. For example:

    var values = [name <- "Alice"]

    if shouldSetEmail {
        values.append(email <- "alice@mac.com")
    }

    if let insertedID = users.insert(values) {
        ...
    }

If you think this is a good idea, `update` should also be changed to allow an array of setters.