### PR TITLE
Support non-integer primary key in shorthand function

### DIFF
--- a/SQLite Tests/SchemaTests.swift
+++ b/SQLite Tests/SchemaTests.swift
@@ -33,6 +33,18 @@ class SchemaTests: SQLiteTestCase {
         AssertSQL("CREATE TABLE \"users\" (\"email\" TEXT NOT NULL)")
     }
 
+    func test_createTable_column_nonIntegerPrimaryKey() {
+        db.create(table: users) { $0.column(email, primaryKey: true) }
+        
+        AssertSQL("CREATE TABLE \"users\" (\"email\" TEXT PRIMARY KEY NOT NULL)")
+    }
+    
+    func test_createTable_column_customTypePrimaryKey() {
+        db.create(table: users) { $0.column(uniqueIdentifier, primaryKey: true) }
+        
+        AssertSQL("CREATE TABLE \"users\" (\"uniqueIdentifier\" TEXT PRIMARY KEY NOT NULL)")
+    }
+
     func test_createTable_column_withPrimaryKey_buildsPrimaryKeyClause() {
         db.create(table: users) { $0.column(id, primaryKey: true) }
 

--- a/SQLite Tests/TestHelper.swift
+++ b/SQLite Tests/TestHelper.swift
@@ -7,6 +7,7 @@ let age = Expression<Int?>("age")
 let salary = Expression<Double>("salary")
 let admin = Expression<Bool>("admin")
 let manager_id = Expression<Int64?>("manager_id")
+let uniqueIdentifier = Expression<UniqueIdentifier>("uniqueIdentifier")
 
 class SQLiteTestCase: XCTestCase {
 
@@ -70,4 +71,17 @@ class SQLiteTestCase: XCTestCase {
         if let count = trace[SQL] { trace[SQL] = count - 1 }
     }
 
+}
+
+
+public class UniqueIdentifier : NSUUID, Value {
+    public static var declaredDatatype = "TEXT"
+    
+    public static func fromDatatypeValue(datatypeValue: String) -> UniqueIdentifier {
+        return UniqueIdentifier(UUIDString: datatypeValue)!
+    }
+    
+    public var datatypeValue: String {
+        return self.UUIDString
+    }
 }

--- a/SQLite/Schema.swift
+++ b/SQLite/Schema.swift
@@ -193,12 +193,8 @@ public final class SchemaBuilder {
     ) {
         column(Expression<V>(name), nil, true, unique, check, value.map { Expression(value: $0) })
     }
-
-    // MARK: - INTEGER Columns
-
-    // MARK: PRIMARY KEY
-
-    public func column<V: Value where V.Datatype == Int64>(
+    
+    public func column<V: Value>(
         name: Expression<V>,
         primaryKey: Bool,
         unique: Bool = false,
@@ -206,6 +202,10 @@ public final class SchemaBuilder {
     ) {
         column(name, primaryKey ? .Default : nil, false, unique, check, nil, nil)
     }
+
+    // MARK: - INTEGER Columns
+
+    // MARK: PRIMARY KEY
 
     public enum PrimaryKey {
 


### PR DESCRIPTION
Rather than rely on the documentation, I figure why not support this directly? 

It has the nice benefit of making the generated SQL syntax match what you'd write by hand, though it doesn't really change the functionality.

Included test of `String` primary key and custom type primary key.