### PR TITLE
Added getter for query to return private columnNames variable

### DIFF
--- a/SQLite/Query.swift
+++ b/SQLite/Query.swift
@@ -658,6 +658,11 @@ public struct Row {
     private init(_ columnNames: [String: Int], _ values: [Binding?]) {
         (self.columnNames, self.values) = (columnNames, values)
     }
+    
+    /// Returns columnNames variable - for mapping select * queries
+    public func getColumnNames() -> [String: Int] {
+        return self.columnNames
+    }
 
     /// Returns a row’s value for the given column.
     ///


### PR DESCRIPTION
When iterating through a result set obtained via a select * query, the exact number of columns is unknown.  The columnNames variable is needed to properly iterate through this kind of result set and this commit provides access to it via the Query object.

    var aliasByColumnName = [String: String]
    var aliases = database("SELECT * FROM ALIASES")
    for alias in aliases {
      var columnNames:[String: Int] = alias.getColumnNames()
      for (key, value) in columnNames {
        aliasByColumnName[key] = alias.values[value]
      }
    }
