### PR TITLE
SQLiteCipher NSData key support

### DIFF
--- a/SQLite.xcodeproj/project.pbxproj
+++ b/SQLite.xcodeproj/project.pbxproj
@@ -130,7 +130,7 @@
 		DCC6B3801A9191C300734B78 /* SQLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCC6B3921A9191D100734B78 /* SQLiteCipher Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SQLiteCipher Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCC6B3961A91938F00734B78 /* sqlcipher.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = sqlcipher.xcodeproj; path = Vendor/sqlcipher/sqlcipher.xcodeproj; sourceTree = "<group>"; };
-		DCC6B3A31A9194A800734B78 /* Cipher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cipher.swift; sourceTree = "<group>"; };
+		DCC6B3A31A9194A800734B78 /* Cipher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cipher.swift; sourceTree = "<group>"; usesTabs = 0; };
 		DCC6B3A51A9194FB00734B78 /* CipherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CipherTests.swift; sourceTree = "<group>"; };
 		DCF37F8119DDAC2D001534AA /* DatabaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseTests.swift; sourceTree = "<group>"; };
 		DCF37F8419DDAF3F001534AA /* StatementTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = StatementTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };

--- a/SQLite/Value.swift
+++ b/SQLite/Value.swift
@@ -62,6 +62,10 @@ public struct Blob {
     public init(bytes: UnsafePointer<Void>, length: Int) {
         data = NSData(bytes: bytes, length: length)
     }
+    
+    public init (data: NSData) {
+        self.data = data
+    }
 
 }
 

--- a/SQLiteCipher/Cipher.swift
+++ b/SQLiteCipher/Cipher.swift
@@ -31,5 +31,9 @@ extension Database {
     public func rekey(key: String) {
         try { sqlite3_rekey(self.handle, key, Int32(count(key.utf8))) }
     }
+	
+	public func key(key: NSData, length: Int32) {
+		try { sqlite3_key(self.handle, key.bytes, length) }
+	}
 
 }

--- a/SQLiteCipher/Cipher.swift
+++ b/SQLiteCipher/Cipher.swift
@@ -35,5 +35,9 @@ extension Database {
 	public func key(key: NSData) {
 		try { sqlite3_key(self.handle, key.bytes, Int32(key.length)) }
 	}
+	
+	public func rekey(key: NSData) {
+		try { sqlite3_rekey(self.handle, key.bytes, Int32(key.length)) }
+	}
 
 }

--- a/SQLiteCipher/Cipher.swift
+++ b/SQLiteCipher/Cipher.swift
@@ -32,12 +32,12 @@ extension Database {
         try { sqlite3_rekey(self.handle, key, Int32(count(key.utf8))) }
     }
 	
-	public func key(key: NSData) {
-		try { sqlite3_key(self.handle, key.bytes, Int32(key.length)) }
-	}
+    public func key(key: Blob) {
+        try { sqlite3_key(self.handle, key.bytes, Int32(key.length)) }
+    }
 	
-	public func rekey(key: NSData) {
-		try { sqlite3_rekey(self.handle, key.bytes, Int32(key.length)) }
-	}
+    public func rekey(key: Blob) {
+        try { sqlite3_rekey(self.handle, key.bytes, Int32(key.length)) }
+    }
 
 }

--- a/SQLiteCipher/Cipher.swift
+++ b/SQLiteCipher/Cipher.swift
@@ -32,8 +32,8 @@ extension Database {
         try { sqlite3_rekey(self.handle, key, Int32(count(key.utf8))) }
     }
 	
-	public func key(key: NSData, length: Int32) {
-		try { sqlite3_key(self.handle, key.bytes, length) }
+	public func key(key: NSData) {
+		try { sqlite3_key(self.handle, key.bytes, Int32(key.length)) }
 	}
 
 }


### PR DESCRIPTION
Adds key and rekey methods that accept a key of type NSData.
This allows the database to be easily keyed with a key generated by
Security.framework:
```swift
let keyData = NSMutableData(length: 64)!
let result = SecRandomCopyBytes(kSecRandomDefault, 64,
UnsafeMutablePointer<UInt8>(keyData.mutableBytes))

db.key(keyData)
```