### PR TITLE
String and String.characters no longer Sliceable

### DIFF
--- a/Source/Typed/Query.swift
+++ b/Source/Typed/Query.swift
@@ -849,7 +849,7 @@ extension Connection {
         let columnNames: [String: Int] = {
             var (columnNames, idx) = ([String: Int](), 0)
             column: for each in query.clauses.select.columns ?? [Expression<Void>(literal: "*")] {
-                var names = each.expression.template.characters.split { $0 == "." }.map(String.init)
+                var names = each.expression.template.componentsSeparatedByString(".")
                 let column = names.removeLast()
                 let namespace = ".".join(names)
 


### PR DESCRIPTION
Xcode-Beta Version 7.0 beta 4 (7A165t) on 2015-08-22 did not think String.characters had a split method.  this .componentsSeparatedByString(String) call appears to do what we needed to do, split the .expression.template on '.'

As an aside, this change allowed this same Xcode/Swift2 version and Carthage 0.7.5 to build all four schemes of SQLite.swift/swift-2 with this Cartfile entry:

github "stephencelis/SQLite.swift" "swift-2"

Though it must be said I've only used the SQLite iOS scheme results.

HTH!  Thank you for this framework!