### PR TITLE
Replace Foundation String format with Swift version

### DIFF
--- a/SQLite Tests/ValueTests.swift
+++ b/SQLite Tests/ValueTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import SQLite
+
+class ValueTests: SQLiteTestCase {
+
+    func test_blob_toHex() {
+        let blob = Blob(
+            data:[0,10,20,30,40,50,60,70,80,90,100,150,250,255] as [UInt8]
+        )
+        XCTAssertEqual(blob.toHex(), "000a141e28323c46505a6496faff")
+    }
+    
+}

--- a/SQLite.xcodeproj/project.pbxproj
+++ b/SQLite.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8E7D32B61B8FB67C003C1892 /* ValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E7D32B51B8FB67C003C1892 /* ValueTests.swift */; };
 		DC109CE11A0C4D970070988E /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC109CE01A0C4D970070988E /* Schema.swift */; };
 		DC109CE41A0C4F5D0070988E /* SchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC109CE31A0C4F5D0070988E /* SchemaTests.swift */; };
 		DC2393C81ABE35F8003FF113 /* SQLite-Bridging.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2393C61ABE35F8003FF113 /* SQLite-Bridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -99,6 +100,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		8E7D32B51B8FB67C003C1892 /* ValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
 		DC109CE01A0C4D970070988E /* Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Schema.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		DC109CE31A0C4F5D0070988E /* SchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchemaTests.swift; sourceTree = "<group>"; };
 		DC2393C61ABE35F8003FF113 /* SQLite-Bridging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SQLite-Bridging.h"; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 				DC109CE31A0C4F5D0070988E /* SchemaTests.swift */,
 				DCAFEAD61AABEFA7000C21A1 /* FTSTests.swift */,
 				DCBE28441ABDF2A80042A3FC /* RTreeTests.swift */,
+				8E7D32B51B8FB67C003C1892 /* ValueTests.swift */,
 				DC37740319C8CBB3004FCF85 /* Supporting Files */,
 			);
 			path = "SQLite Tests";
@@ -505,6 +508,7 @@
 				DC475EA219F219AF00788FBD /* ExpressionTests.swift in Sources */,
 				DCAD429A19E2EE50004A51DF /* QueryTests.swift in Sources */,
 				DC109CE41A0C4F5D0070988E /* SchemaTests.swift in Sources */,
+				8E7D32B61B8FB67C003C1892 /* ValueTests.swift in Sources */,
 				DCC6B3A71A91974B00734B78 /* FunctionsTests.swift in Sources */,
 				DCBE28451ABDF2A80042A3FC /* RTreeTests.swift in Sources */,
 			);

--- a/SQLite/Value.swift
+++ b/SQLite/Value.swift
@@ -45,7 +45,9 @@ public protocol Value {
 
 }
 
-public struct Blob: Equatable {
+private let hexChars: [Character] = Array("0123456789abcdef")
+
+public struct Blob: Equatable, Printable {
 
     public let data: [UInt8]
     
@@ -59,12 +61,29 @@ public struct Blob: Equatable {
             count: length
         ))
     }
+    
+    public func toHex() -> String {
+        var string: String = ""
+        string.reserveCapacity(data.count*2)
+        for byte in data {
+            let a = hexChars[Int(byte >> 4)]
+            let b = hexChars[Int(byte & 0xF)]
+            string.append(a)
+            string.append(b)
+        }
+        return string
+    }
+    
+    public var description: String {
+        return "x'\(toHex())'"
+    }
 
 }
 
 public func ==(lhs: Blob, rhs: Blob) -> Bool {
     return lhs.data == rhs.data
 }
+
 
 extension Blob {
     public var bytes: UnsafePointer<Void> {
@@ -86,16 +105,6 @@ extension Blob: Binding, Value {
 
     public var datatypeValue: Blob {
         return self
-    }
-
-}
-
-extension Blob: Printable {
-
-    public var description: String {
-        let buf = UnsafeBufferPointer(start: UnsafePointer<UInt8>(bytes), count: length)
-        let hex = join("", map(buf) { String(format: "%02x", $0) })
-        return "x'\(hex)'"
     }
 
 }


### PR DESCRIPTION
Missed a Foundation dependency that is automatically bridged: `String(format:)`. Some reason it still works without the import.

Added toHex() method to Blob and replaced `String(format:)` in Blob.description with it. Added a test for it.