### PR TITLE
propagate errors in Statement initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,22 +56,22 @@ let insert = users.insert(name <- "Alice", email <- "alice@mac.com")
 let rowid = try db.run(insert)
 // INSERT INTO "users" ("name", "email") VALUES ('Alice', 'alice@mac.com')
 
-for user in db.prepare(users) {
-    println("id: \(user[id]), name: \(user[name]), email: \(user[email])")
+for user in try db.prepare(users) {
+    print("id: \(user[id]), name: \(user[name]), email: \(user[email])")
     // id: 1, name: Optional("Alice"), email: alice@mac.com
 }
 // SELECT * FROM "users"
 
 let alice = users.filter(id == rowid)
 
-try db.run(alice.update(email <- email.replace("mac.com", "me.com")))
+try db.run(alice.update(email <- email.replace("mac.com", with: "me.com")))
 // UPDATE "users" SET "email" = replace("email", 'mac.com', 'me.com')
 // WHERE ("id" = 1)
 
 try db.run(alice.delete())
 // DELETE FROM "users" WHERE ("id" = 1)
 
-db.scalar(users.count) // 0
+try db.scalar(users.count) // 0
 // SELECT count(*) FROM "users"
 ```
 
@@ -79,22 +79,22 @@ SQLite.swift also works as a lightweight, Swift-friendly wrapper over the C
 API.
 
 ``` swift
-let stmt = db.prepare("INSERT INTO users (email) VALUES (?)")
+let stmt = try db.prepare("INSERT INTO users (email) VALUES (?)")
 for email in ["betty@icloud.com", "cathy@icloud.com"] {
-    stmt.run(email)
+    try stmt.run(email)
 }
 
 db.totalChanges    // 3
 db.changes         // 1
 db.lastInsertRowid // 3
 
-for row in db.prepare("SELECT id, email FROM users") {
-    println("id: \(row[0]), email: \(row[1])")
+for row in try db.prepare("SELECT id, email FROM users") {
+    print("id: \(row[0]), email: \(row[1])")
     // id: Optional(2), email: Optional("betty@icloud.com")
     // id: Optional(3), email: Optional("cathy@icloud.com")
 }
 
-db.scalar("SELECT count(*) FROM users") // 2
+try db.scalar("SELECT count(*) FROM users") // 2
 ```
 
 [Read the documentation][See Documentation] or explore more,

--- a/SQLite.playground/Contents.swift
+++ b/SQLite.playground/Contents.swift
@@ -19,7 +19,7 @@ try! db.run(users.create { t in
 let rowid = try! db.run(users.insert(email <- "alice@mac.com"))
 let alice = users.filter(id == rowid)
 
-for user in db.prepare(users) {
+for user in try! db.prepare(users) {
     print("id: \(user[id]), email: \(user[email])")
 }
 
@@ -35,9 +35,9 @@ try! db.run(emails.insert(
     body <- "This is a hello world message."
 ))
 
-let row = db.pluck(emails.match("hello"))
+let row = try! db.pluck(emails.match("hello"))
 
-let query = db.prepare(emails.match("hello"))
+let query = try! db.prepare(emails.match("hello"))
 for row in query {
     print(row[subject])
 }

--- a/Source/Core/Connection.swift
+++ b/Source/Core/Connection.swift
@@ -140,9 +140,9 @@ public final class Connection {
     ///   - bindings: A list of parameters to bind to the statement.
     ///
     /// - Returns: A prepared statement.
-    @warn_unused_result public func prepare(statement: String, _ bindings: Binding?...) -> Statement {
-        if !bindings.isEmpty { return prepare(statement, bindings) }
-        return Statement(self, statement)
+    @warn_unused_result public func prepare(statement: String, _ bindings: Binding?...) throws -> Statement {
+        if !bindings.isEmpty { return try prepare(statement, bindings) }
+        return try Statement(self, statement)
     }
 
     /// Prepares a single SQL statement and binds parameters to it.
@@ -154,8 +154,8 @@ public final class Connection {
     ///   - bindings: A list of parameters to bind to the statement.
     ///
     /// - Returns: A prepared statement.
-    @warn_unused_result public func prepare(statement: String, _ bindings: [Binding?]) -> Statement {
-        return prepare(statement).bind(bindings)
+    @warn_unused_result public func prepare(statement: String, _ bindings: [Binding?]) throws -> Statement {
+        return try prepare(statement).bind(bindings)
     }
 
     /// Prepares a single SQL statement and binds parameters to it.
@@ -167,8 +167,8 @@ public final class Connection {
     ///   - bindings: A dictionary of named parameters to bind to the statement.
     ///
     /// - Returns: A prepared statement.
-    @warn_unused_result public func prepare(statement: String, _ bindings: [String: Binding?]) -> Statement {
-        return prepare(statement).bind(bindings)
+    @warn_unused_result public func prepare(statement: String, _ bindings: [String: Binding?]) throws -> Statement {
+        return try prepare(statement).bind(bindings)
     }
 
     // MARK: - Run
@@ -230,8 +230,8 @@ public final class Connection {
     ///   - bindings: A list of parameters to bind to the statement.
     ///
     /// - Returns: The first value of the first row returned.
-    @warn_unused_result public func scalar(statement: String, _ bindings: Binding?...) -> Binding? {
-        return scalar(statement, bindings)
+    @warn_unused_result public func scalar(statement: String, _ bindings: Binding?...) throws -> Binding? {
+        return try scalar(statement, bindings)
     }
 
     /// Runs a single SQL statement (with optional parameter bindings),
@@ -244,8 +244,8 @@ public final class Connection {
     ///   - bindings: A list of parameters to bind to the statement.
     ///
     /// - Returns: The first value of the first row returned.
-    @warn_unused_result public func scalar(statement: String, _ bindings: [Binding?]) -> Binding? {
-        return prepare(statement).scalar(bindings)
+    @warn_unused_result public func scalar(statement: String, _ bindings: [Binding?]) throws -> Binding? {
+        return try prepare(statement).scalar(bindings)
     }
 
     /// Runs a single SQL statement (with optional parameter bindings),
@@ -258,8 +258,8 @@ public final class Connection {
     ///   - bindings: A dictionary of named parameters to bind to the statement.
     ///
     /// - Returns: The first value of the first row returned.
-    @warn_unused_result public func scalar(statement: String, _ bindings: [String: Binding?]) -> Binding? {
-        return prepare(statement).scalar(bindings)
+    @warn_unused_result public func scalar(statement: String, _ bindings: [String: Binding?]) throws -> Binding? {
+        return try prepare(statement).scalar(bindings)
     }
 
     // MARK: - Transactions

--- a/Source/Core/Statement.swift
+++ b/Source/Core/Statement.swift
@@ -29,9 +29,9 @@ public final class Statement {
 
     private let connection: Connection
 
-    init(_ connection: Connection, _ SQL: String) {
+    init(_ connection: Connection, _ SQL: String) throws {
         self.connection = connection
-        try! connection.check(sqlite3_prepare_v2(connection.handle, SQL, -1, &handle, nil))
+        try connection.check(sqlite3_prepare_v2(connection.handle, SQL, -1, &handle, nil))
     }
 
     deinit {

--- a/Source/Core/Statement.swift
+++ b/Source/Core/Statement.swift
@@ -146,21 +146,21 @@ public final class Statement {
     /// - Parameter bindings: A list of parameters to bind to the statement.
     ///
     /// - Returns: The first value of the first row returned.
-    @warn_unused_result public func scalar(bindings: Binding?...) -> Binding? {
+    @warn_unused_result public func scalar(bindings: Binding?...) throws -> Binding? {
         guard bindings.isEmpty else {
-            return scalar(bindings)
+            return try scalar(bindings)
         }
 
         reset(clearBindings: false)
-        try! step()
+        try step()
         return row[0]
     }
 
     /// - Parameter bindings: A list of parameters to bind to the statement.
     ///
     /// - Returns: The first value of the first row returned.
-    @warn_unused_result public func scalar(bindings: [Binding?]) -> Binding? {
-        return bind(bindings).scalar()
+    @warn_unused_result public func scalar(bindings: [Binding?]) throws -> Binding? {
+        return try bind(bindings).scalar()
     }
 
 
@@ -168,8 +168,8 @@ public final class Statement {
     ///   statement.
     ///
     /// - Returns: The first value of the first row returned.
-    @warn_unused_result public func scalar(bindings: [String: Binding?]) -> Binding? {
-        return bind(bindings).scalar()
+    @warn_unused_result public func scalar(bindings: [String: Binding?]) throws -> Binding? {
+        return try bind(bindings).scalar()
     }
 
     public func step() throws -> Bool {

--- a/Tests/ConnectionTests.swift
+++ b/Tests/ConnectionTests.swift
@@ -72,10 +72,10 @@ class ConnectionTests : SQLiteTestCase {
     }
 
     func test_prepare_preparesAndReturnsStatements() {
-        _ = db.prepare("SELECT * FROM users WHERE admin = 0")
-        _ = db.prepare("SELECT * FROM users WHERE admin = ?", 0)
-        _ = db.prepare("SELECT * FROM users WHERE admin = ?", [0])
-        _ = db.prepare("SELECT * FROM users WHERE admin = $admin", ["$admin": 0])
+        _ = try! db.prepare("SELECT * FROM users WHERE admin = 0")
+        _ = try! db.prepare("SELECT * FROM users WHERE admin = ?", 0)
+        _ = try! db.prepare("SELECT * FROM users WHERE admin = ?", [0])
+        _ = try! db.prepare("SELECT * FROM users WHERE admin = $admin", ["$admin": 0])
     }
 
     func test_run_preparesRunsAndReturnsStatements() {
@@ -87,10 +87,10 @@ class ConnectionTests : SQLiteTestCase {
     }
 
     func test_scalar_preparesRunsAndReturnsScalarValues() {
-        XCTAssertEqual(0, db.scalar("SELECT count(*) FROM users WHERE admin = 0") as? Int64)
-        XCTAssertEqual(0, db.scalar("SELECT count(*) FROM users WHERE admin = ?", 0) as? Int64)
-        XCTAssertEqual(0, db.scalar("SELECT count(*) FROM users WHERE admin = ?", [0]) as? Int64)
-        XCTAssertEqual(0, db.scalar("SELECT count(*) FROM users WHERE admin = $admin", ["$admin": 0]) as? Int64)
+        XCTAssertEqual(0, try! db.scalar("SELECT count(*) FROM users WHERE admin = 0") as? Int64)
+        XCTAssertEqual(0, try! db.scalar("SELECT count(*) FROM users WHERE admin = ?", 0) as? Int64)
+        XCTAssertEqual(0, try! db.scalar("SELECT count(*) FROM users WHERE admin = ?", [0]) as? Int64)
+        XCTAssertEqual(0, try! db.scalar("SELECT count(*) FROM users WHERE admin = $admin", ["$admin": 0]) as? Int64)
         AssertSQL("SELECT count(*) FROM users WHERE admin = 0", 4)
     }
 
@@ -113,7 +113,7 @@ class ConnectionTests : SQLiteTestCase {
     }
 
     func test_transaction_beginsAndCommitsTransactions() {
-        let stmt = db.prepare("INSERT INTO users (email) VALUES (?)", "alice@example.com")
+        let stmt = try! db.prepare("INSERT INTO users (email) VALUES (?)", "alice@example.com")
 
         try! db.transaction {
             try stmt.run()
@@ -126,7 +126,7 @@ class ConnectionTests : SQLiteTestCase {
     }
 
     func test_transaction_beginsAndRollsTransactionsBack() {
-        let stmt = db.prepare("INSERT INTO users (email) VALUES (?)", "alice@example.com")
+        let stmt = try! db.prepare("INSERT INTO users (email) VALUES (?)", "alice@example.com")
 
         do {
             try db.transaction {
@@ -162,7 +162,7 @@ class ConnectionTests : SQLiteTestCase {
 
     func test_savepoint_beginsAndRollsSavepointsBack() {
         let db = self.db
-        let stmt = db.prepare("INSERT INTO users (email) VALUES (?)", "alice@example.com")
+        let stmt = try! db.prepare("INSERT INTO users (email) VALUES (?)", "alice@example.com")
 
         do {
             try db.savepoint("1") {
@@ -238,7 +238,7 @@ class ConnectionTests : SQLiteTestCase {
             try! db.transaction {
                 try InsertUser("alice")
             }
-            XCTAssertEqual(1, db.scalar("SELECT count(*) FROM users") as? Int64)
+            XCTAssertEqual(1, try! db.scalar("SELECT count(*) FROM users") as? Int64)
         }
     }
 
@@ -252,7 +252,7 @@ class ConnectionTests : SQLiteTestCase {
                 }
             } catch {
             }
-            XCTAssertEqual(0, db.scalar("SELECT count(*) FROM users") as? Int64)
+            XCTAssertEqual(0, try! db.scalar("SELECT count(*) FROM users") as? Int64)
         }
     }
 
@@ -268,36 +268,36 @@ class ConnectionTests : SQLiteTestCase {
                 }
             } catch {
             }
-            XCTAssertEqual(0, db.scalar("SELECT count(*) FROM users") as? Int64)
+            XCTAssertEqual(0, try! db.scalar("SELECT count(*) FROM users") as? Int64)
         }
     }
 
     func test_createFunction_withArrayArguments() {
         db.createFunction("hello") { $0[0].map { "Hello, \($0)!" } }
 
-        XCTAssertEqual("Hello, world!", db.scalar("SELECT hello('world')") as? String)
-        XCTAssert(db.scalar("SELECT hello(NULL)") == nil)
+        XCTAssertEqual("Hello, world!", try! db.scalar("SELECT hello('world')") as? String)
+        XCTAssert(try! db.scalar("SELECT hello(NULL)") == nil)
     }
 
     func test_createFunction_createsQuotableFunction() {
         db.createFunction("hello world") { $0[0].map { "Hello, \($0)!" } }
 
-        XCTAssertEqual("Hello, world!", db.scalar("SELECT \"hello world\"('world')") as? String)
-        XCTAssert(db.scalar("SELECT \"hello world\"(NULL)") == nil)
+        XCTAssertEqual("Hello, world!", try! db.scalar("SELECT \"hello world\"('world')") as? String)
+        XCTAssert(try! db.scalar("SELECT \"hello world\"(NULL)") == nil)
     }
 
     func test_createCollation_createsCollation() {
         db.createCollation("NODIACRITIC") { lhs, rhs in
             return lhs.compare(rhs, options: .DiacriticInsensitiveSearch)
         }
-        XCTAssertEqual(1, db.scalar("SELECT ? = ? COLLATE NODIACRITIC", "cafe", "café") as? Int64)
+        XCTAssertEqual(1, try! db.scalar("SELECT ? = ? COLLATE NODIACRITIC", "cafe", "café") as? Int64)
     }
 
     func test_createCollation_createsQuotableCollation() {
         db.createCollation("NO DIACRITIC") { lhs, rhs in
             return lhs.compare(rhs, options: .DiacriticInsensitiveSearch)
         }
-        XCTAssertEqual(1, db.scalar("SELECT ? = ? COLLATE \"NO DIACRITIC\"", "cafe", "café") as? Int64)
+        XCTAssertEqual(1, try! db.scalar("SELECT ? = ? COLLATE \"NO DIACRITIC\"", "cafe", "café") as? Int64)
     }
 
     func test_interrupt_interruptsLongRunningQuery() {
@@ -307,7 +307,7 @@ class ConnectionTests : SQLiteTestCase {
             return nil
         }
 
-        let stmt = db.prepare("SELECT *, sleep(?) FROM users", 0.1)
+        let stmt = try! db.prepare("SELECT *, sleep(?) FROM users", 0.1)
         try! stmt.run()
 
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(10 * NSEC_PER_MSEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), db.interrupt)

--- a/Tests/FTS4Tests.swift
+++ b/Tests/FTS4Tests.swift
@@ -71,7 +71,7 @@ class FTS4IntegrationTests : SQLiteTestCase {
         AssertSQL("CREATE VIRTUAL TABLE \"emails\" USING fts4(\"subject\", \"body\", tokenize=\"SQLite.swift\" \"tokenizer\")")
 
         try! db.run(emails.insert(subject <- "Aún más cáfe!"))
-        XCTAssertEqual(1, db.scalar(emails.filter(emails.match("aun")).count))
+        XCTAssertEqual(1, try! db.scalar(emails.filter(emails.match("aun")).count))
     }
 
 }

--- a/Tests/QueryTests.swift
+++ b/Tests/QueryTests.swift
@@ -278,7 +278,7 @@ class QueryIntegrationTests : SQLiteTestCase {
     // MARK: -
 
     func test_select() {
-        for _ in db.prepare(users) {
+        for _ in try! db.prepare(users) {
             // FIXME
         }
 
@@ -288,22 +288,22 @@ class QueryIntegrationTests : SQLiteTestCase {
         let alice = try! db.run(users.insert(email <- "alice@example.com"))
         try! db.run(users.insert(email <- "betsy@example.com", managerId <- alice))
 
-        for user in db.prepare(users.join(managers, on: managers[id] == users[managerId])) {
+        for user in try! db.prepare(users.join(managers, on: managers[id] == users[managerId])) {
             user[users[managerId]]
         }
     }
 
     func test_scalar() {
-        XCTAssertEqual(0, db.scalar(users.count))
-        XCTAssertEqual(false, db.scalar(users.exists))
+        XCTAssertEqual(0, try! db.scalar(users.count))
+        XCTAssertEqual(false, try! db.scalar(users.exists))
 
         try! InsertUsers("alice")
-        XCTAssertEqual(1, db.scalar(users.select(id.average)))
+        XCTAssertEqual(1, try! db.scalar(users.select(id.average)))
     }
 
     func test_pluck() {
         let rowid = try! db.run(users.insert(email <- "alice@example.com"))
-        XCTAssertEqual(rowid, db.pluck(users)![id])
+        XCTAssertEqual(rowid, try! db.pluck(users)![id])
     }
 
     func test_insert() {


### PR DESCRIPTION
Propagates up errors by replacing a `try!` in the init method for Statements with try and adding the necessary acknowledgements of this throughout the code.

see: https://github.com/stephencelis/SQLite.swift/issues/220