### PR TITLE
Solve [!] Invalid `SQLite.swift.podspec` file: cannot infer basepath

### DIFF
--- a/SQLite.swift.podspec
+++ b/SQLite.swift.podspec
@@ -1,4 +1,5 @@
-require_relative 'Supporting Files/podspec.rb'
+$LOAD_PATH << '.'
+require 'Supporting Files/podspec.rb'
 
 Pod::Spec.new do |spec|
   spec.name = 'SQLite.swift'


### PR DESCRIPTION
The **require_relative** is not working, changed to **require** and setting the $LOAD_PATH previously