### PR TITLE
Add order method to query that takes an array arg

### DIFF
--- a/Source/Typed/Query.swift
+++ b/Source/Typed/Query.swift
@@ -399,6 +399,22 @@ extension QueryType {
     ///
     /// - Returns: A query with the given `ORDER BY` clause applied.
     public func order(by: Expressible...) -> Self {
+        return order(by)
+    }
+    
+    /// Sets an `ORDER BY` clause on the query.
+    ///
+    ///     let users = Table("users")
+    ///     let email = Expression<String>("email")
+    ///     let name = Expression<String?>("name")
+    ///
+    ///     users.order([email.desc, name.asc])
+    ///     // SELECT * FROM "users" ORDER BY "email" DESC, "name" ASC
+    ///
+    /// - Parameter by: An ordered list of columns and directions to sort by.
+    ///
+    /// - Returns: A query with the given `ORDER BY` clause applied.
+    public func order(by: [Expressible]) -> Self {
         var query = self
         query.clauses.order = by
         return query

--- a/Source/Typed/Query.swift
+++ b/Source/Typed/Query.swift
@@ -390,7 +390,7 @@ extension QueryType {
     ///
     ///     let users = Table("users")
     ///     let email = Expression<String>("email")
-    ///     let email = Expression<String?>("name")
+    ///     let name = Expression<String?>("name")
     ///
     ///     users.order(email.desc, name.asc)
     ///     // SELECT * FROM "users" ORDER BY "email" DESC, "name" ASC

--- a/Tests/QueryTests.swift
+++ b/Tests/QueryTests.swift
@@ -120,6 +120,10 @@ class QueryTests : XCTestCase {
         AssertSQL("SELECT * FROM \"users\" ORDER BY \"age\", \"email\"", users.order(age, email))
     }
 
+    func test_order_withArrayExpressionNames_compilesOrderClause() {
+        AssertSQL("SELECT * FROM \"users\" ORDER BY \"age\", \"email\"", users.order([age, email]))
+    }
+
     func test_order_withExpressionAndSortDirection_compilesOrderClause() {
 //        AssertSQL("SELECT * FROM \"users\" ORDER BY \"age\" DESC, \"email\" ASC", users.order(age.desc, email.asc))
     }


### PR DESCRIPTION
The same thing exists for `group` so I figured not having one for `order` might have been an oversight.

Copy/pasted the documentation from above (just like `group`).
Tests still pass.

:smile: 