### PR TITLE
Start moving issues into tracking document, minor docs example tweak

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -1450,13 +1450,15 @@ Though we recommend you stick with SQLite.swift’s [type-safe system](#building
     db.changes // -> {Some 1}
     ```
 
-    Statements with results may be iterated over.
+    Statements with results may be iterated over, using the columnNames if useful.
 
     ``` swift
     let stmt = try db.prepare("SELECT id, email FROM users")
     for row in stmt {
-        print("id: \(row[0]), email: \(row[1])")
-        // id: Optional(1), email: Optional("alice@mac.com")
+        for (index, name) in stmt.columnNames.enumerate() {
+            print ("\(name)=\(row[index]!)")
+            // id: Optional(1), email: Optional("alice@mac.com")
+        }
     }
     ```
 

--- a/Documentation/Planning.md
+++ b/Documentation/Planning.md
@@ -1,0 +1,33 @@
+# SQLite.swift Planning
+
+This document captures both near term steps (aka Roadmap) and feature requests. 
+The goal is to add some visibility and guidance for future additions and Pull Requests, as well as to keep the Issues list clear of enhancement requests so that bugs are more visible.
+
+## Roadmap
+
+_Lists agreed upon next steps in approximate priority order._
+
+ * publish to the CocoaPods directory at https://cocoapods.org/, per #257
+ * add SQLCipher back into the product as a separate repo, per #311
+
+
+## Feature Requests
+
+_A gathering point for ideas for new features. In general, the corresponding issue will be closed once it is added here, with the assumption that it will be referred to when it comes time to add the corresponding feature._
+
+### Packaging
+
+ * add TV OS support, per #272 - currently pending SQLiteCipher merge and/or adding ability for user to pick their preferred [SQLCipher](https://github.com/sqlcipher/sqlcipher) branch
+ * linux support via Swift Package Manager, per #315
+
+### Features
+
+ * provide separate threads for update vs read, so updates don't block reads, per #236
+ * expose more FTS4 options, e.g. virtual table support per #164
+ * expose triggers, per #164
+
+## Suspended Feature Requests
+
+_Features that are not actively being considered, perhaps because of no clean type-safe way to implement them with the current Swift, or bugs, or just general uncertainty._
+
+ * provide a mechanism for INSERT INTO multiple values, per #168 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ To install SQLite.swift with [SQLCipher][] support:
 
 ## Communication
 
+[See the planning document] for a roadmap and existing feature requests.
+
 [Read the contributing guidelines][]. The _TL;DR_ (but please; _R_):
 
  - Need **help** or have a **general question**? [Ask on Stack
@@ -220,6 +222,7 @@ To install SQLite.swift with [SQLCipher][] support:
  - Found a **bug** or have a **feature request**? [Open an issue][].
  - Want to **contribute**? [Submit a pull request][].
 
+[See the planning document]: /Documentation/Planning.md 
 [Read the contributing guidelines]: ./CONTRIBUTING.md#contributing
 [Ask on Stack Overflow]: http://stackoverflow.com/questions/tagged/sqlite.swift
 [Open an issue]: https://github.com/stephencelis/SQLite.swift/issues/new


### PR DESCRIPTION
_Note: This PR only affects document files. It does NOT change any code._

To try and help out (after checking with @stephencelis), I've been going through the issues to pull out enhancement requests and also to propose a roadmap for priorities. This PR is my first stab at this. If accepted, I'll close the referenced issues.

Why? My thesis is that the less open issues the better, for the following reasons:
 * many projects have a roadmap and this can be a useful guide for people and cut down on repeat questions
 * it's nice to see if a feature request has already been made and find a link to the history (via a closed issue, in this case)
 * if there are just a few issues open, it's easier to look for things to help, or known problems
 * I often judge a project's quality by how many issues are open and how long they've been there. Not a great guide, but I'm sure I'm not alone. 
