### PR TITLE
SQLiteCipher NSData key support

### DIFF
--- a/Source/Cipher/Cipher.swift
+++ b/Source/Cipher/Cipher.swift
@@ -36,4 +36,16 @@ extension Connection {
         try check(sqlite3_rekey(handle, key, Int32(key.utf8.count)))
     }
 
+    public func key(key: Blob) throws {
+        try check(sqlite3_key(handle, key.bytes, Int32(key.bytes.count)))
+        try execute(
+            "CREATE TABLE \"__SQLCipher.swift__\" (\"cipher key check\");\n" +
+            "DROP TABLE \"__SQLCipher.swift__\";"
+        )
+    }
+    
+    public func rekey(key: Blob) throws {
+        try check(sqlite3_rekey(handle, key.bytes, Int32(key.bytes.count)))
+    }
+    
 }

--- a/Tests/CipherTests.swift
+++ b/Tests/CipherTests.swift
@@ -16,7 +16,7 @@ class CipherTests: XCTestCase {
         // db2
         let keyData = NSMutableData(length: 64)!
         let _ = SecRandomCopyBytes(kSecRandomDefault, 64, UnsafeMutablePointer<UInt8>(keyData.mutableBytes))
-        try! db2.key("hello")
+        try! db2.key(Blob(bytes: keyData.bytes, length: keyData.length))
         
         try! db2.run("CREATE TABLE foo (bar TEXT)")
         try! db2.run("INSERT INTO foo (bar) VALUES ('world')")


### PR DESCRIPTION
Adds key and rekey methods that accept a key of type NSData.
This allows the database to be easily keyed with a key generated by
Security.framework:

```swift
let keyData = NSMutableData(length: 64)!
SecRandomCopyBytes(kSecRandomDefault, 64,
UnsafeMutablePointer<UInt8>(keyData.mutableBytes))
db.key(Blob(bytes: keyData.bytes, length: keyData.length))
```

