### PR TITLE
0.9.2 candidate. Hopefully fixes: #324, #325, #326

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -78,7 +78,7 @@ install SQLite.swift with Carthage:
  2. Update your Cartfile to include the following:
 
     ```
-    github "stephencelis/SQLite.swift" ~> 0.9.1
+    github "stephencelis/SQLite.swift" ~> 0.9.2
     ```
 
  3. Run `carthage update` and [add the appropriate framework][Carthage Usage].
@@ -100,7 +100,7 @@ install SQLite.swift with Carthage:
     ``` ruby
     use_frameworks!
 
-    pod 'SQLite.swift', '~> 0.9.1'
+    pod 'SQLite.swift', '~> 0.9.2'
     ```
 
  3. Run `pod install`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# SQLite.swift [![Build Status][Badge]][Travis]
+# SQLite.swift 
+
+[![Build Status][Badge]][Travis] [![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/SQLite.swift/badge.png)](http://cocoadocs.org/docsets/SQLite.swift) [![Platform](https://cocoapod-badges.herokuapp.com/p/SQLite.swift/badge.png)](http://cocoadocs.org/docsets/SQLite.swift) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 A type-safe, [Swift][]-language layer over [SQLite3][].
 
@@ -124,7 +126,7 @@ install SQLite.swift with Carthage:
  2. Update your Cartfile to include the following:
 
     ```
-    github "stephencelis/SQLite.swift" ~> 0.9.1
+    github "stephencelis/SQLite.swift" ~> 0.9.2
     ```
 
  3. Run `carthage update` and [add the appropriate framework][Carthage Usage].
@@ -148,7 +150,7 @@ SQLite.swift with CocoaPods:
     ``` ruby
     use_frameworks!
 
-    pod 'SQLite.swift', '~> 0.9.1'
+    pod 'SQLite.swift', '~> 0.9.2'
     ```
 
  3. Run `pod install`.

--- a/SQLite.swift.podspec
+++ b/SQLite.swift.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SQLite.swift"
-  s.version          = "0.9.1"
+  s.version          = "0.9.2"
   s.summary          = "A type-safe, Swift-language layer over SQLite3 for iOS and OS X."
 
   s.description      = <<-DESC
@@ -21,12 +21,11 @@ Pod::Spec.new do |s|
 
   s.module_name      = 'SQLite'
   s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.0"
+  s.osx.deployment_target = "10.9"
 
+  s.module_map = "podstuff/module.modulemap"
+  s.xcconfig = { 'OTHER_LDFLAGS': '-lsqlite3' }
   s.source_files = 'SQLite/**/*'
   s.private_header_files = 'SQLite/Core/fts3_tokenizer.h'
-
-  # make the sqlite3 C library behave like a module
-  s.libraries        = 'sqlite3'
-  s.xcconfig         = { 'SWIFT_INCLUDE_PATHS' => '${PODS_ROOT}/SQLite.swift/SQLite3' }
-  s.preserve_path    = 'SQLite3/*'
 end

--- a/SQLite.swift.podspec
+++ b/SQLite.swift.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.9"
 
   s.module_map = "podstuff/module.modulemap"
-  s.xcconfig = { 'OTHER_LDFLAGS': '-lsqlite3' }
+  s.libraries = 'sqlite3'
   s.source_files = 'SQLite/**/*'
   s.private_header_files = 'SQLite/Core/fts3_tokenizer.h'
 end

--- a/SQLite.xcodeproj/project.pbxproj
+++ b/SQLite.xcodeproj/project.pbxproj
@@ -79,6 +79,12 @@
 		EE247B731C3F3FEC00AE3E12 /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE247B001C3F06E900AE3E12 /* Query.swift */; };
 		EE247B741C3F3FEC00AE3E12 /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE247B011C3F06E900AE3E12 /* Schema.swift */; };
 		EE247B751C3F3FEC00AE3E12 /* Setter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE247B021C3F06E900AE3E12 /* Setter.swift */; };
+		EE91808C1C46E34A0038162A /* usr/include/sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = EE91808B1C46E34A0038162A /* usr/include/sqlite3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE91808E1C46E5230038162A /* SQLite-Bridging.h in Headers */ = {isa = PBXBuildFile; fileRef = EE91808D1C46E5230038162A /* SQLite-Bridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE91808F1C46E76D0038162A /* SQLite-Bridging.h in Headers */ = {isa = PBXBuildFile; fileRef = EE91808D1C46E5230038162A /* SQLite-Bridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE9180901C46E8980038162A /* usr/include/sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = EE91808B1C46E34A0038162A /* usr/include/sqlite3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE9180941C46EA210038162A /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = EE9180931C46EA210038162A /* libsqlite3.tbd */; };
+		EE9180951C46EBCC0038162A /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = EE9180911C46E9D30038162A /* libsqlite3.tbd */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -148,6 +154,10 @@
 		EE247B911C3F822500AE3E12 /* installation@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "installation@2x.png"; sourceTree = "<group>"; };
 		EE247B921C3F822600AE3E12 /* playground@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "playground@2x.png"; sourceTree = "<group>"; };
 		EE247B931C3F826100AE3E12 /* SQLite.swift.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = SQLite.swift.podspec; sourceTree = "<group>"; };
+		EE91808B1C46E34A0038162A /* usr/include/sqlite3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = usr/include/sqlite3.h; sourceTree = SDKROOT; };
+		EE91808D1C46E5230038162A /* SQLite-Bridging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SQLite-Bridging.h"; sourceTree = "<group>"; };
+		EE9180911C46E9D30038162A /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
+		EE9180931C46EA210038162A /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -155,6 +165,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE9180941C46EA210038162A /* libsqlite3.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,6 +181,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE9180951C46EBCC0038162A /* libsqlite3.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,6 +220,7 @@
 		EE247AD51C3F04ED00AE3E12 /* SQLite */ = {
 			isa = PBXGroup;
 			children = (
+				EE91808B1C46E34A0038162A /* usr/include/sqlite3.h */,
 				EE247AD61C3F04ED00AE3E12 /* SQLite.h */,
 				EE247AF71C3F06E900AE3E12 /* Foundation.swift */,
 				EE247AF81C3F06E900AE3E12 /* Helpers.swift */,
@@ -245,6 +258,7 @@
 		EE247AED1C3F06E900AE3E12 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				EE91808D1C46E5230038162A /* SQLite-Bridging.h */,
 				EE247AEE1C3F06E900AE3E12 /* Blob.swift */,
 				EE247AEF1C3F06E900AE3E12 /* Connection.swift */,
 				EE247AF01C3F06E900AE3E12 /* fts3_tokenizer.h */,
@@ -288,6 +302,8 @@
 				EE247B931C3F826100AE3E12 /* SQLite.swift.podspec */,
 				EE247B8C1C3F821200AE3E12 /* .travis.yml */,
 				EE247B8D1C3F821200AE3E12 /* Makefile */,
+				EE9180931C46EA210038162A /* libsqlite3.tbd */,
+				EE9180911C46E9D30038162A /* libsqlite3.tbd */,
 				EE247B8E1C3F822500AE3E12 /* Documentation */,
 			);
 			name = Metadata;
@@ -318,7 +334,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE91808E1C46E5230038162A /* SQLite-Bridging.h in Headers */,
 				EE247B051C3F06E900AE3E12 /* fts3_tokenizer.h in Headers */,
+				EE91808C1C46E34A0038162A /* usr/include/sqlite3.h in Headers */,
 				EE247AD71C3F04ED00AE3E12 /* SQLite.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -327,8 +345,10 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE9180901C46E8980038162A /* usr/include/sqlite3.h in Headers */,
 				EE247B671C3F3FEC00AE3E12 /* fts3_tokenizer.h in Headers */,
 				EE247B621C3F3FDB00AE3E12 /* SQLite.h in Headers */,
+				EE91808F1C46E76D0038162A /* SQLite-Bridging.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -701,7 +721,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLite;
 				PRODUCT_NAME = SQLite;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/SQLite3";
+				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -722,7 +742,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLite;
 				PRODUCT_NAME = SQLite;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/SQLite3";
+				SWIFT_INCLUDE_PATHS = "";
 			};
 			name = Release;
 		};
@@ -765,7 +785,7 @@
 				PRODUCT_NAME = SQLite;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "${SRCROOT}/SQLite3";
+				SWIFT_INCLUDE_PATHS = "";
 			};
 			name = Debug;
 		};
@@ -788,7 +808,7 @@
 				PRODUCT_NAME = SQLite;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "${SRCROOT}/SQLite3";
+				SWIFT_INCLUDE_PATHS = "";
 			};
 			name = Release;
 		};

--- a/SQLite/Core/Connection.swift
+++ b/SQLite/Core/Connection.swift
@@ -23,7 +23,6 @@
 //
 
 import Dispatch
-import SQLite3
 
 /// A connection to SQLite.
 public final class Connection {

--- a/SQLite/Core/SQLite-Bridging.h
+++ b/SQLite/Core/SQLite-Bridging.h
@@ -22,40 +22,16 @@
 // THE SOFTWARE.
 //
 
-public struct Blob {
+@import Foundation;
 
-    public let bytes: [UInt8]
+#ifndef COCOAPODS
+#import "sqlite3.h"
+#endif
 
-    public init(bytes: [UInt8]) {
-        self.bytes = bytes
-    }
+typedef struct SQLiteHandle SQLiteHandle; // CocoaPods workaround
 
-    public init(bytes: UnsafePointer<Void>, length: Int) {
-        self.init(bytes: [UInt8](UnsafeBufferPointer(
-            start: UnsafePointer(bytes), count: length
-        )))
-    }
+NS_ASSUME_NONNULL_BEGIN
+typedef NSString * _Nullable (^_SQLiteTokenizerNextCallback)(const char * input, int * inputOffset, int * inputLength);
+int _SQLiteRegisterTokenizer(SQLiteHandle * db, const char * module, const char * tokenizer, _Nullable _SQLiteTokenizerNextCallback callback);
+NS_ASSUME_NONNULL_END
 
-    public func toHex() -> String {
-        return bytes.map {
-            ($0 < 16 ? "0" : "") + String($0, radix: 16, uppercase: false)
-        }.joinWithSeparator("")
-    }
-
-}
-
-extension Blob : CustomStringConvertible {
-
-    public var description: String {
-        return "x'\(toHex())'"
-    }
-
-}
-
-extension Blob : Equatable {
-
-}
-
-public func ==(lhs: Blob, rhs: Blob) -> Bool {
-    return lhs.bytes == rhs.bytes
-}

--- a/SQLite/Core/SQLite-Bridging.m
+++ b/SQLite/Core/SQLite-Bridging.m
@@ -22,11 +22,9 @@
 // THE SOFTWARE.
 //
 
-#import "fts3_tokenizer.h"
-
+#import "SQLite-Bridging.h"
 #import "sqlite3.h"
-
-#import <SQLite.h>
+#import "fts3_tokenizer.h"
 
 #pragma mark - FTS
 

--- a/SQLite/Core/Statement.swift
+++ b/SQLite/Core/Statement.swift
@@ -22,8 +22,6 @@
 // THE SOFTWARE.
 //
 
-import SQLite3
-
 /// A single SQL statement.
 public final class Statement {
 

--- a/SQLite/Helpers.swift
+++ b/SQLite/Helpers.swift
@@ -22,8 +22,6 @@
 // THE SOFTWARE.
 //
 
-import SQLite3
-
 public typealias Star = (Expression<Binding>?, Expression<Binding>?) -> Expression<Void>
 
 public func *(_: Expression<Binding>?, _: Expression<Binding>?) -> Expression<Void> {

--- a/SQLite/Info.plist
+++ b/SQLite/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.1</string>
+	<string>0.9.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SQLite/SQLite.h
+++ b/SQLite/SQLite.h
@@ -3,9 +3,4 @@
 FOUNDATION_EXPORT double SQLiteVersionNumber;
 FOUNDATION_EXPORT const unsigned char SQLiteVersionString[];
 
-typedef struct SQLiteHandle SQLiteHandle; // ??? - CocoaPods workaround
-
-NS_ASSUME_NONNULL_BEGIN
-typedef NSString * _Nullable (^_SQLiteTokenizerNextCallback)(const char * input, int * inputOffset, int * inputLength);
-int _SQLiteRegisterTokenizer(SQLiteHandle * db, const char * module, const char * tokenizer, _Nullable _SQLiteTokenizerNextCallback callback);
-NS_ASSUME_NONNULL_END
+#import <SQLite/SQLite-Bridging.h>

--- a/SQLite3/module.modulemap
+++ b/SQLite3/module.modulemap
@@ -1,8 +1,0 @@
-module SQLite3 [system] {
-    // Requires latest Xcode installed in standard path.
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/sqlite3.h"
-
-    link "sqlite3"
-
-    export *
-}

--- a/podstuff/module.modulemap
+++ b/podstuff/module.modulemap
@@ -1,0 +1,12 @@
+framework module SQLite {
+    umbrella header "SQLite.h"
+
+    // Load the SDK header alongside SQLite.swift. Alternate headers:
+    //
+    //     header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/sqlite3.h"
+    //     header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/include/sqlite3.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/sqlite3.h"
+
+    export *
+    module * { export * }
+}


### PR DESCRIPTION
 * Revert including sqlite3 as an Xcode module to fix #324 and instead use the sqlite.h file and linked library setting
 * Add back some of the CocoaPod tweaks from prior to 0.9.0
 * Add `tvos` to the podspec for #325. Add `OSX` while we're there.
 * Possibly fix #326, though it's a bit hard to say without more info what is actually going on there.
 * update docs to be 0.9.2
 * add some pretty buttons to the top of the readme - (the "platform iOS" should become ios/tvos/osx once this is pushed to CocoaPods)
