### PR TITLE
Fixes #335 - allow OSX 10.9 and above instead of 10.11

### DIFF
--- a/SQLite.xcodeproj/project.pbxproj
+++ b/SQLite.xcodeproj/project.pbxproj
@@ -780,7 +780,7 @@
 				INFOPLIST_FILE = SQlite/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQlite;
 				PRODUCT_NAME = SQLite;
 				SDKROOT = macosx;
@@ -803,7 +803,7 @@
 				INFOPLIST_FILE = SQlite/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQlite;
 				PRODUCT_NAME = SQLite;
 				SDKROOT = macosx;


### PR DESCRIPTION
Reminder: will need to tag this update for Carthage to be happy.