### PR TITLE
Fix Carthage build errors on case-sensitive filesystem

### DIFF
--- a/SQLite.xcodeproj/project.pbxproj
+++ b/SQLite.xcodeproj/project.pbxproj
@@ -100,7 +100,7 @@
 			containerPortal = EE247ACA1C3F04ED00AE3E12 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = EE247B3B1C3F3ED000AE3E12;
-			remoteInfo = SQlite;
+			remoteInfo = SQLite;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -405,7 +405,7 @@
 			dependencies = (
 			);
 			name = "SQLite Mac";
-			productName = SQlite;
+			productName = SQLite;
 			productReference = EE247B3C1C3F3ED000AE3E12 /* SQLite.framework */;
 			productType = "com.apple.product-type.framework";
 		};
@@ -423,7 +423,7 @@
 				EE247B481C3F3ED000AE3E12 /* PBXTargetDependency */,
 			);
 			name = "SQLiteTests Mac";
-			productName = SQliteTests;
+			productName = SQLiteTests;
 			productReference = EE247B451C3F3ED000AE3E12 /* SQLiteTests Mac.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
@@ -777,11 +777,11 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = SQlite/Info.plist;
+				INFOPLIST_FILE = SQLite/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQlite;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLite;
 				PRODUCT_NAME = SQLite;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -800,11 +800,11 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = SQlite/Info.plist;
+				INFOPLIST_FILE = SQLite/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQlite;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLite;
 				PRODUCT_NAME = SQLite;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -817,10 +817,10 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = SQliteTests/Info.plist;
+				INFOPLIST_FILE = SQLiteTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQliteTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLiteTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -831,10 +831,10 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = SQliteTests/Info.plist;
+				INFOPLIST_FILE = SQLiteTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQliteTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLiteTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};


### PR DESCRIPTION
SQLite fails to build with Carthage on Macs with case sensitive file system.  The build fails with:

    The following build commands failed:
    	ProcessInfoPlistFile /Users/mkistler/Library/Developer/Xcode/DerivedData/SQLite-fciegensodowgvfsgoskujfmqkpa/Build/Products/Release/SQLite.framework/Versions/A/Resources/Info.plist SQlite/Info.plist
    (1 failure)
    error: could not read data from '/Users/mkistler/Projects/myproj/Carthage/Checkouts/SQLite.swift/SQlite/Info.plist': The file “Info.plist” couldn’t be opened because there is no such file.
    A shell task failed with exit code 65:
    ** BUILD FAILED **

The nut of the problem is that the "L" in "SQLite" must be capitalized or the build will fail on Macs that have case-sensitive filesystems.