### PR TITLE
Swift22 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_install:
   - gem install xcpretty --no-document
 script:
   - make test
-osx_image: xcode7
+osx_image: xcode7.3

--- a/SQLite/Core/Statement.swift
+++ b/SQLite/Core/Statement.swift
@@ -271,7 +271,7 @@ extension Cursor : SequenceType {
 
     public func generate() -> AnyGenerator<Binding?> {
         var idx = 0
-        return anyGenerator {
+        return AnyGenerator {
             idx >= self.columnCount ? Optional<Binding?>.None : self[idx++]
         }
     }

--- a/SQLite/Core/Statement.swift
+++ b/SQLite/Core/Statement.swift
@@ -272,7 +272,12 @@ extension Cursor : SequenceType {
     public func generate() -> AnyGenerator<Binding?> {
         var idx = 0
         return AnyGenerator {
-            idx >= self.columnCount ? Optional<Binding?>.None : self[idx++]
+            if idx >= self.columnCount {
+                return Optional<Binding?>.None
+            } else {
+                idx += 1
+                return self[idx - 1]
+            }
         }
     }
 

--- a/SQLite/Core/Value.swift
+++ b/SQLite/Core/Value.swift
@@ -33,9 +33,9 @@ public protocol Number : Binding {}
 
 public protocol Value : Expressible { // extensions cannot have inheritance clauses
 
-    typealias ValueType = Self
+    associatedtype ValueType = Self
 
-    typealias Datatype : Binding
+    associatedtype Datatype : Binding
 
     static var declaredDatatype: String { get }
 

--- a/SQLite/Extensions/FTS4.swift
+++ b/SQLite/Extensions/FTS4.swift
@@ -28,7 +28,9 @@ extension Module {
         return FTS4([column] + more)
     }
 
-    @warn_unused_result public static func FTS4(var columns: [Expressible] = [], tokenize tokenizer: Tokenizer? = nil) -> Module {
+    @warn_unused_result public static func FTS4(columns: [Expressible] = [], tokenize tokenizer: Tokenizer? = nil) -> Module {
+        var columns = columns
+        
         if let tokenizer = tokenizer {
             columns.append("=".join([Expression<Void>(literal: "tokenize"), Expression<Void>(literal: tokenizer.description)]))
         }

--- a/SQLite/Helpers.swift
+++ b/SQLite/Helpers.swift
@@ -30,7 +30,7 @@ public func *(_: Expression<Binding>?, _: Expression<Binding>?) -> Expression<Vo
 
 public protocol _OptionalType {
 
-    typealias WrappedType
+    associatedtype WrappedType
 
 }
 

--- a/SQLite/Helpers.swift
+++ b/SQLite/Helpers.swift
@@ -88,15 +88,15 @@ extension String {
 
 }
 
-@warn_unused_result func infix<T>(lhs: Expressible, _ rhs: Expressible, wrap: Bool = true, function: String = __FUNCTION__) -> Expression<T> {
+@warn_unused_result func infix<T>(lhs: Expressible, _ rhs: Expressible, wrap: Bool = true, function: String = #function) -> Expression<T> {
     return function.infix(lhs, rhs, wrap: wrap)
 }
 
-@warn_unused_result func wrap<T>(expression: Expressible, function: String = __FUNCTION__) -> Expression<T> {
+@warn_unused_result func wrap<T>(expression: Expressible, function: String = #function) -> Expression<T> {
     return function.wrap(expression)
 }
 
-@warn_unused_result func wrap<T>(expressions: [Expressible], function: String = __FUNCTION__) -> Expression<T> {
+@warn_unused_result func wrap<T>(expressions: [Expressible], function: String = #function) -> Expression<T> {
     return function.wrap(", ".join(expressions))
 }
 

--- a/SQLite/Typed/Expression.swift
+++ b/SQLite/Typed/Expression.swift
@@ -24,7 +24,7 @@
 
 public protocol ExpressionType : Expressible { // extensions cannot have inheritance clauses
 
-    typealias UnderlyingType = Void
+    associatedtype UnderlyingType = Void
 
     var template: String { get }
     var bindings: [Binding?] { get }

--- a/SQLite/Typed/Expression.swift
+++ b/SQLite/Typed/Expression.swift
@@ -78,7 +78,15 @@ extension Expressible {
         let expressed = expression
         var idx = 0
         return expressed.template.characters.reduce("") { template, character in
-            return template + (character == "?" ? transcode(expressed.bindings[idx++]) : String(character))
+            let transcoded: String
+            
+            if character == "?" {
+                transcoded = transcode(expressed.bindings[idx])
+                idx += 1
+            } else {
+                transcoded = String(character)
+            }
+            return template + transcoded
         }
     }
 

--- a/SQLite/Typed/Query.swift
+++ b/SQLite/Typed/Query.swift
@@ -920,7 +920,7 @@ extension Connection {
         }()
 
         return AnySequence {
-            anyGenerator { statement.next().map { Row(columnNames, $0) } }
+            AnyGenerator { statement.next().map { Row(columnNames, $0) } }
         }
     }
 

--- a/SQLite/Typed/Query.swift
+++ b/SQLite/Typed/Query.swift
@@ -891,7 +891,7 @@ extension Connection {
                         let e = q.expression
                         var names = try self.prepare(e.template, e.bindings).columnNames.map { $0.quote() }
                         if namespace { names = names.map { "\(query.tableName().expression.template).\($0)" } }
-                        for name in names { columnNames[name] = idx++ }
+                        for name in names { columnNames[name] = idx; idx += 1 }
                     }
                 }
 
@@ -914,7 +914,8 @@ extension Connection {
                     continue
                 }
 
-                columnNames[each.expression.template] = idx++
+                columnNames[each.expression.template] = idx
+                idx += 1
             }
             return columnNames
         }()

--- a/SQLiteTests/TestHelpers.swift
+++ b/SQLiteTests/TestHelpers.swift
@@ -47,7 +47,7 @@ class SQLiteTestCase : XCTestCase {
         )
     }
 
-    func AssertSQL(SQL: String, _ executions: Int = 1, _ message: String? = nil, file: String = __FILE__, line: UInt = __LINE__) {
+    func AssertSQL(SQL: String, _ executions: Int = 1, _ message: String? = nil, file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(
             executions, trace[SQL] ?? 0,
             message ?? SQL,
@@ -55,7 +55,7 @@ class SQLiteTestCase : XCTestCase {
         )
     }
 
-    func AssertSQL(SQL: String, _ statement: Statement, _ message: String? = nil, file: String = __FILE__, line: UInt = __LINE__) {
+    func AssertSQL(SQL: String, _ statement: Statement, _ message: String? = nil, file: StaticString = #file, line: UInt = #line) {
         try! statement.run()
         AssertSQL(SQL, 1, message, file: file, line: line)
         if let count = trace[SQL] { trace[SQL] = count - 1 }
@@ -96,11 +96,11 @@ let int64Optional = Expression<Int64?>("int64Optional")
 let string = Expression<String>("string")
 let stringOptional = Expression<String?>("stringOptional")
 
-func AssertSQL(@autoclosure expression1: () -> String, @autoclosure _ expression2: () -> Expressible, file: String = __FILE__, line: UInt = __LINE__) {
+func AssertSQL(@autoclosure expression1: () -> String, @autoclosure _ expression2: () -> Expressible, file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(expression1(), expression2().asSQL(), file: file, line: line)
 }
 
-func AssertThrows<T>(@autoclosure expression: () throws -> T, file: String = __FILE__, line: UInt = __LINE__) {
+func AssertThrows<T>(@autoclosure expression: () throws -> T, file: StaticString = #file, line: UInt = #line) {
     do {
         try expression()
         XCTFail("expression expected to throw", file: file, line: line)


### PR DESCRIPTION
This PR resolves build errors in test target connected with change in declaration of one of XCTest methods (String was replaced with StaticString). It also resolves all warnings about deprecation of ++ operators etc. This PR should be merged after official release of Xcode 7.3.