### PR TITLE
Update module.modulemap for Xcode 7.3

### DIFF
--- a/podstuff/module.modulemap
+++ b/podstuff/module.modulemap
@@ -5,7 +5,18 @@ framework module SQLite {
     //
     //     header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/sqlite3.h"
     //     header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/include/sqlite3.h"
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/sqlite3.h"
+    //     header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/sqlite3.h"
+    module arm {
+        header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/sqlite3.h"
+        link "sqlite3"
+        requires arm
+    }
+    
+    module x86 {
+        header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/sqlite3.h"
+        link "sqlite3"
+        requires x86
+    }
 
     export *
     module * { export * }

--- a/podstuff/module.modulemap
+++ b/podstuff/module.modulemap
@@ -8,15 +8,20 @@ framework module SQLite {
     //     header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/sqlite3.h"
     module arm {
         header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/sqlite3.h"
-        link "sqlite3"
         requires arm
+    }
+    
+    module arm64 {
+        header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/sqlite3.h"
+        requires arm64
     }
     
     module x86 {
         header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/sqlite3.h"
-        link "sqlite3"
         requires x86
     }
+    
+    link "sqlite3"
 
     export *
     module * { export * }


### PR DESCRIPTION
Imports the SDK based on current architecture. Fixes incompatibility problems for Xcode 7.3.
Also includes link flag for convenience.