### PR TITLE
Restrict use of qualified table names

### DIFF
--- a/SQLite/Typed/Query.swift
+++ b/SQLite/Typed/Query.swift
@@ -744,6 +744,13 @@ extension QueryType {
         ])
     }
 
+    func tableName(qualified qualified: Bool) -> Expressible {
+        if qualified {
+            return tableName()
+        }
+        return Expression<Void>(clauses.from.alias ?? clauses.from.name)
+    }
+
     func database(namespace name: String) -> Expressible {
         let name = Expression<Void>(name)
 

--- a/SQLite/Typed/Schema.swift
+++ b/SQLite/Typed/Schema.swift
@@ -134,7 +134,7 @@ extension Table {
         let clauses: [Expressible?] = [
             create("INDEX", indexName(columns), unique ? .Unique : nil, ifNotExists),
             Expression<Void>(literal: "ON"),
-            tableName(),
+            tableName(qualified: false),
             "".wrap(columns) as Expression<Void>
         ]
 

--- a/SQLite/Typed/Schema.swift
+++ b/SQLite/Typed/Schema.swift
@@ -505,7 +505,7 @@ private func definition(column: Expressible, _ datatype: String, _ primaryKey: P
 private func reference(primary: (QueryType, Expressible)) -> Expressible {
     return " ".join([
         Expression<Void>(literal: "REFERENCES"),
-        primary.0.tableName(),
+        primary.0.tableName(qualified: false),
         "".wrap(primary.1) as Expression<Void>
     ])
 }

--- a/SQLiteTests/SchemaTests.swift
+++ b/SQLiteTests/SchemaTests.swift
@@ -724,6 +724,10 @@ class SchemaTests : XCTestCase {
             "CREATE UNIQUE INDEX IF NOT EXISTS \"index_table_on_int64\" ON \"table\" (\"int64\")",
             table.createIndex([int64], unique: true, ifNotExists: true)
         )
+        XCTAssertEqual(
+            "CREATE UNIQUE INDEX IF NOT EXISTS \"main\".\"index_table_on_int64\" ON \"table\" (\"int64\")",
+            Table("table", database: "main").createIndex([int64], unique: true, ifNotExists: true)
+        )
     }
 
     func test_dropIndex_compilesCreateIndexExpression() {

--- a/SQLiteTests/SchemaTests.swift
+++ b/SQLiteTests/SchemaTests.swift
@@ -301,6 +301,10 @@ class SchemaTests : XCTestCase {
             table.create { t in t.column(int64, references: table, int64) }
         )
         XCTAssertEqual(
+            "CREATE TABLE \"table\" (\"int64\" INTEGER NOT NULL REFERENCES \"table\" (\"int64\"))",
+            table.create { t in t.column(int64, references: qualifiedTable, int64) }
+        )
+        XCTAssertEqual(
             "CREATE TABLE \"table\" (\"int64\" INTEGER NOT NULL UNIQUE REFERENCES \"table\" (\"int64\"))",
             table.create { t in t.column(int64, unique: true, references: table, int64) }
         )
@@ -726,7 +730,7 @@ class SchemaTests : XCTestCase {
         )
         XCTAssertEqual(
             "CREATE UNIQUE INDEX IF NOT EXISTS \"main\".\"index_table_on_int64\" ON \"table\" (\"int64\")",
-            Table("table", database: "main").createIndex([int64], unique: true, ifNotExists: true)
+            qualifiedTable.createIndex([int64], unique: true, ifNotExists: true)
         )
     }
 

--- a/SQLiteTests/TestHelpers.swift
+++ b/SQLiteTests/TestHelpers.swift
@@ -110,5 +110,6 @@ func AssertThrows<T>(@autoclosure expression: () throws -> T, file: StaticString
 }
 
 let table = Table("table")
+let qualifiedTable = Table("table", database: "main")
 let virtualTable = VirtualTable("virtual_table")
 let _view = View("view") // avoid Mac XCTestCase collision


### PR DESCRIPTION
Qualified table names are not allowed when creating indexes or foreign key references.

Fixes #395