### PR TITLE
CocoaPods: build standalone version of SQLite with subspec

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -111,8 +111,26 @@ install SQLite.swift with Carthage:
 
  3. Run `pod install`.
 
+ #### Requiring a specific version of SQLite
+
+ If you want to use a more recent version of SQLite than what is provided with the OS you can require the `standalone` subspec:
+
+``` ruby
+    pod 'SQLite.swift/standalone', '~> 0.10.1'
+```
+
+By default this will use the most recent version of SQLite without any extras. If you want you can further customize this by adding another dependency to sqlite3 or one of its subspecs:
+
+``` ruby
+    pod 'SQLite.swift/standalone', '~> 0.10.1'
+    pod 'sqlite3/fts5', '= 3.11.1'  # SQLite 3.11.1 with FTS5 enabled
+```
+
+See the [sqlite3 podspec][sqlite3pod] for more details.
+
 [CocoaPods]: https://cocoapods.org
 [CocoaPods Installation]: https://guides.cocoapods.org/using/getting-started.html#getting-started
+[sqlite3pod]: https://github.com/clemensg/sqlite3pod
 
 
 ### Manual

--- a/SQLite.swift.podspec
+++ b/SQLite.swift.podspec
@@ -24,19 +24,30 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
   s.osx.deployment_target = "10.9"
   s.watchos.deployment_target = "2.0"
+  s.default_subspec  = 'standard'
 
-  s.preserve_paths = 'CocoaPods/**/*'
-  s.pod_target_xcconfig = {
-    'SWIFT_INCLUDE_PATHS[sdk=macosx*]'           => '$(SRCROOT)/SQLite.swift/CocoaPods/macosx',
-    'SWIFT_INCLUDE_PATHS[sdk=iphoneos*]'         => '$(SRCROOT)/SQLite.swift/CocoaPods/iphoneos',
-    'SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]'  => '$(SRCROOT)/SQLite.swift/CocoaPods/iphonesimulator',
-    'SWIFT_INCLUDE_PATHS[sdk=appletvos*]'        => '$(SRCROOT)/SQLite.swift/CocoaPods/appletvos',
-    'SWIFT_INCLUDE_PATHS[sdk=appletvsimulator*]' => '$(SRCROOT)/SQLite.swift/CocoaPods/appletvsimulator',
-    'SWIFT_INCLUDE_PATHS[sdk=watchos*]'          => '$(SRCROOT)/SQLite.swift/CocoaPods/watchos',
-    'SWIFT_INCLUDE_PATHS[sdk=watchsimulator*]'   => '$(SRCROOT)/SQLite.swift/CocoaPods/watchsimulator'
-  }
+  s.subspec 'standard' do |ss|
+    ss.source_files = 'SQLite/**/*.{c,h,m,swift}'
+    ss.private_header_files = 'SQLite/Core/fts3_tokenizer.h'
 
-  s.libraries = 'sqlite3'
-  s.source_files = 'SQLite/**/*.{c,h,m,swift}'
-  s.private_header_files = 'SQLite/Core/fts3_tokenizer.h'
+    ss.library = 'sqlite3'
+    ss.preserve_paths = 'CocoaPods/**/*'
+    ss.pod_target_xcconfig = {
+      'SWIFT_INCLUDE_PATHS[sdk=macosx*]'           => '$(SRCROOT)/SQLite.swift/CocoaPods/macosx',
+      'SWIFT_INCLUDE_PATHS[sdk=iphoneos*]'         => '$(SRCROOT)/SQLite.swift/CocoaPods/iphoneos',
+      'SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]'  => '$(SRCROOT)/SQLite.swift/CocoaPods/iphonesimulator',
+      'SWIFT_INCLUDE_PATHS[sdk=appletvos*]'        => '$(SRCROOT)/SQLite.swift/CocoaPods/appletvos',
+      'SWIFT_INCLUDE_PATHS[sdk=appletvsimulator*]' => '$(SRCROOT)/SQLite.swift/CocoaPods/appletvsimulator',
+      'SWIFT_INCLUDE_PATHS[sdk=watchos*]'          => '$(SRCROOT)/SQLite.swift/CocoaPods/watchos',
+      'SWIFT_INCLUDE_PATHS[sdk=watchsimulator*]'   => '$(SRCROOT)/SQLite.swift/CocoaPods/watchsimulator'
+    }
+  end
+
+  s.subspec 'standalone' do |ss|
+    ss.source_files = 'SQLite/**/*.{c,h,m,swift}'
+    ss.private_header_files = 'SQLite/Core/fts3_tokenizer.h'
+    ss.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -DSQLITE_SWIFT_STANDALONE' }
+
+    ss.dependency 'sqlite3'
+  end
 end

--- a/SQLite/Core/Connection.swift
+++ b/SQLite/Core/Connection.swift
@@ -23,7 +23,11 @@
 //
 
 import Dispatch
+#if SQLITE_SWIFT_STANDALONE
+import sqlite3
+#else
 import CSQLite
+#endif
 
 /// A connection to SQLite.
 public final class Connection {

--- a/SQLite/Core/Statement.swift
+++ b/SQLite/Core/Statement.swift
@@ -22,7 +22,11 @@
 // THE SOFTWARE.
 //
 
+#if SQLITE_SWIFT_STANDALONE
+import sqlite3
+#else
 import CSQLite
+#endif
 
 /// A single SQL statement.
 public final class Statement {

--- a/SQLite/Helpers.swift
+++ b/SQLite/Helpers.swift
@@ -22,7 +22,11 @@
 // THE SOFTWARE.
 //
 
+#if SQLITE_SWIFT_STANDALONE
+import sqlite3
+#else
 import CSQLite
+#endif
 
 public typealias Star = (Expression<Binding>?, Expression<Binding>?) -> Expression<Void>
 


### PR DESCRIPTION
Adresses #401.

Not sure about the "standalone" spec name – I just followed the pattern used in https://github.com/ccgus/fmdb/blob/master/FMDB.podspec.

Passes `pod spec lint --allow-warnings`.

The existing behavior and setup is left unchanged. I can't think of a good way to integrate the SQLite sources in a submodule, maybe this could be addressed in a separate PR.

It also needs tests – maybe a dummy project could be set up automatically, including test suite.