### PR TITLE
I have a database where there can be an empty ( non nil ) date string

### DIFF
--- a/SQLite/Foundation.swift
+++ b/SQLite/Foundation.swift
@@ -47,7 +47,7 @@ extension NSDate : Value {
     }
 
     public class func fromDatatypeValue(stringValue: String) -> NSDate {
-        return dateFormatter.dateFromString(stringValue)!
+        return dateFormatter.dateFromString(stringValue) ?? NSDate()
     }
 
     public var datatypeValue: String {


### PR DESCRIPTION
A better solution would be to either provide a default value for the case when the string is not a well formed date or to make fromDatatypeValue() return an optional NSDate and return nil if anything goes wrong.
