### PR TITLE
Use SQLITE_OPEN_NOMUTEX for readonly database to avoid locking

### DIFF
--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -102,10 +102,10 @@ public final class Connection {
     ///     Default: `false`.
     ///
     /// - Returns: A new database connection.
-    public init(_ location: Location = .inMemory, readonly: Bool = false) throws {
-        let flags = readonly ? SQLITE_OPEN_READONLY : SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE
-        try check(sqlite3_open_v2(location.description, &_handle, flags | SQLITE_OPEN_FULLMUTEX, nil))
-        queue.setSpecific(key: Connection.queueKey, value: queueContext)
+    public init(_ location: Location = .InMemory, readonly: Bool = false) throws {
+        let flags = readonly ? (SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX) : (SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX)
+        try check(sqlite3_open_v2(location.description, &_handle, flags, nil))
+        dispatch_queue_set_specific(queue, Connection.queueKey, queueContext, nil)
     }
 
     /// Initializes a new connection to a database.

--- a/Tests/SQLiteTests/ConnectionTests.swift
+++ b/Tests/SQLiteTests/ConnectionTests.swift
@@ -45,6 +45,11 @@ class ConnectionTests : SQLiteTestCase {
         let db = try! Connection("\(NSTemporaryDirectory())/SQLite.swift Tests.sqlite3")
         XCTAssertEqual("\(NSTemporaryDirectory())/SQLite.swift Tests.sqlite3", db.description)
     }
+    
+    func test_init_withOpenFlags_returnsURIConnection() {
+        let db = try! Connection("\(NSTemporaryDirectory())/SQLite.swift Tests.sqlite3", flags: [.sharedcache, .create, .readwrite])
+        XCTAssertEqual("\(NSTemporaryDirectory())/SQLite.swift Tests.sqlite3", db.description)
+    }
 
     func test_readonly_returnsFalseOnReadWriteConnections() {
         XCTAssertFalse(db.readonly)


### PR DESCRIPTION
According to the SQLite docs, if the SQLITE_OPEN_NOMUTEX flag is set, then the database connection opens in the multi-thread threading mode. This change will make it so that readonly database connections will have muti-threaded access since there's no risk of trying to write while reading. It keeps SQLITE_OPEN_FULLMUTEX for write databases.

Docs here: https://www.sqlite.org/c3ref/open.html
