### PR TITLE
Run desired unit tests instead of only Mac.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 BUILD_TOOL = xcodebuild
-BUILD_SCHEME = SQLite Mac
-BUILD_ARGUMENTS = -scheme "$(BUILD_SCHEME)"
+ifeq ($(BUILD_SCHEME),SQLite iOS)
+	BUILD_ARGUMENTS = -scheme "$(BUILD_SCHEME)" -sdk iphonesimulator
+else
+	BUILD_ARGUMENTS = -scheme "$(BUILD_SCHEME)"
+endif
 
 XCPRETTY := $(shell command -v xcpretty)
 SWIFTCOV := $(shell command -v swiftcov)


### PR DESCRIPTION
If you look at the logs of any of the previous travis builds, they all run Mac tests, even when the scheme is set to "SQLite iOS". This should fix that.