### PR TITLE
Fixed NSData to Blob bridge extension

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -1178,12 +1178,12 @@ Any object that can be encoded and decoded can be stored as a blob of data in SQ
 We can create an `NSData` bridge rather trivially.
 
 ``` swift
-extension NSData: Value {
+extension NSData{
     class var declaredDatatype: String {
         return Blob.declaredDatatype
     }
     class func fromDatatypeValue(blobValue: Blob) -> Self {
-        return self(bytes: blobValue.bytes, length: blobValue.length)
+        return self(bytes: blobValue.bytes, length: blobValue.bytes.count)
     }
     var datatypeValue: Blob {
         return Blob(bytes: bytes, length: length)

--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -1175,10 +1175,10 @@ let published = posts.filter(published_at <= NSDate())
 
 Any object that can be encoded and decoded can be stored as a blob of data in SQL.
 
-We can create an `NSData` bridge rather trivially.
+An `NSData` bridge can be created rather trivially. It is already included in the SQLite.swift.
 
 ``` swift
-extension NSData{
+extension NSData: Value {
     class var declaredDatatype: String {
         return Blob.declaredDatatype
     }


### PR DESCRIPTION
Related to issue #337

Sqlite.Blob.length is deprecated, need to use Sqlite.Blob.bytes.count instead
