### PR TITLE
Only import CSQLite module when building with CocoaPods

### DIFF
--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -28,7 +28,7 @@ import Dispatch
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#else
+#elseif COCOAPODS
 import CSQLite
 #endif
 

--- a/Sources/SQLite/Core/Statement.swift
+++ b/Sources/SQLite/Core/Statement.swift
@@ -26,7 +26,7 @@
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#else
+#elseif COCOAPODS
 import CSQLite
 #endif
 

--- a/Sources/SQLite/Helpers.swift
+++ b/Sources/SQLite/Helpers.swift
@@ -26,7 +26,7 @@
 import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
-#else
+#elseif COCOAPODS
 import CSQLite
 #endif
 


### PR DESCRIPTION
Issue #492 re-appeared so I made the change in db8f39b which was done in PR #502 again to fix it.

I'm using Xcode 8.2.1 and my Xcode app is placed in `/Applications/Xcode.app`. I only have one Xcode app installed.