### PR TITLE
Make Row.get throw instead of crash.

### DIFF
--- a/Sources/SQLite/Foundation.swift
+++ b/Sources/SQLite/Foundation.swift
@@ -92,17 +92,17 @@ extension QueryType {
 extension Row {
 
     public subscript(column: Expression<Data>) -> Data {
-        return get(column)
+        return try! get(column)
     }
     public subscript(column: Expression<Data?>) -> Data? {
-        return get(column)
+        return try! get(column)
     }
 
     public subscript(column: Expression<Date>) -> Date {
-        return get(column)
+        return try! get(column)
     }
     public subscript(column: Expression<Date?>) -> Date? {
-        return get(column)
+        return try! get(column)
     }
 
 }


### PR DESCRIPTION
This isn't backwards compatible with the old `.get`, but subscripts still work the same. I figure most use subscripts so this won't be too big of a deal, but if you want me to think of a backwards compatible way to do this, let me know.