### PR TITLE
Added a way to check if a row has a value for a column

### DIFF
--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1062,6 +1062,18 @@ public struct Row {
         return valueAtIndex(idx)
     }
 
+    /// Checks if the row has a value for the given column.
+    ///
+    /// - Parameter column: An expression representing a column selected in a Query.
+    ///
+    /// - Returns: True if the row has a value for the given column.
+    public func hasColumn<V: Value>(_ column: Expression<V>) -> Bool {
+        return hasColumn(Expression<V?>(column))
+    }
+    public func hasColumn<V: Value>(_ column: Expression<V?>) -> Bool {
+        return (columnNames[column.template] != nil)
+    }
+
     // FIXME: rdar://problem/18673897 // subscript<T>…
 
     public subscript(column: Expression<Blob>) -> Blob {


### PR DESCRIPTION
This PR adds a way to check if a result row has a value for a column.

This is useful when you make requests on sqlite databases that may not have some columns (ex: doing a select * and a previous version of the database didn't have the column). Currently, there is no way to know if the column is available, and in this case using the getter on a Row makes a fatalError that can't be caught. With this addition, it is possible to call hasColumn on a Row to check it before.