### PR TITLE
Fix usages of old Swift 2 enum case names

### DIFF
--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -38,12 +38,12 @@ public final class Connection {
     /// The location of a SQLite database.
     public enum Location {
 
-        /// An in-memory database (equivalent to `.URI(":memory:")`).
+        /// An in-memory database (equivalent to `.uri(":memory:")`).
         ///
         /// See: <https://www.sqlite.org/inmemorydb.html#sharedmemdb>
         case inMemory
 
-        /// A temporary, file-backed database (equivalent to `.URI("")`).
+        /// A temporary, file-backed database (equivalent to `.uri("")`).
         ///
         /// See: <https://www.sqlite.org/inmemorydb.html#temp_db>
         case temporary
@@ -93,7 +93,7 @@ public final class Connection {
     ///   - location: The location of the database. Creates a new database if it
     ///     doesn’t already exist (unless in read-only mode).
     ///
-    ///     Default: `.InMemory`.
+    ///     Default: `.inMemory`.
     ///
     ///   - readonly: Whether or not to open the database in a read-only state.
     ///
@@ -321,7 +321,7 @@ public final class Connection {
     ///
     ///   - mode: The mode in which a transaction acquires a lock.
     ///
-    ///     Default: `.Deferred`
+    ///     Default: `.deferred`
     ///
     ///   - block: A closure to run SQL statements within the transaction.
     ///     The transaction will be committed when the block returns. The block

--- a/Sources/SQLite/Typed/Schema.swift
+++ b/Sources/SQLite/Typed/Schema.swift
@@ -42,7 +42,7 @@ extension Table {
         block(builder)
 
         let clauses: [Expressible?] = [
-            create(Table.identifier, tableName(), temporary ? .Temporary : nil, ifNotExists),
+            create(Table.identifier, tableName(), temporary ? .temporary : nil, ifNotExists),
             "".wrap(builder.definitions) as Expression<Void>,
             withoutRowid ? Expression<Void>(literal: "WITHOUT ROWID") : nil
         ]
@@ -52,7 +52,7 @@ extension Table {
 
     public func create(_ query: QueryType, temporary: Bool = false, ifNotExists: Bool = false) -> String {
         let clauses: [Expressible?] = [
-            create(Table.identifier, tableName(), temporary ? .Temporary : nil, ifNotExists),
+            create(Table.identifier, tableName(), temporary ? .temporary : nil, ifNotExists),
             Expression<Void>(literal: "AS"),
             query
         ]
@@ -133,7 +133,7 @@ extension Table {
 
     public func createIndex(_ columns: [Expressible], unique: Bool = false, ifNotExists: Bool = false) -> String {
         let clauses: [Expressible?] = [
-            create("INDEX", indexName(columns), unique ? .Unique : nil, ifNotExists),
+            create("INDEX", indexName(columns), unique ? .unique : nil, ifNotExists),
             Expression<Void>(literal: "ON"),
             tableName(qualified: false),
             "".wrap(columns) as Expression<Void>
@@ -176,7 +176,7 @@ extension View {
 
     public func create(_ query: QueryType, temporary: Bool = false, ifNotExists: Bool = false) -> String {
         let clauses: [Expressible?] = [
-            create(View.identifier, tableName(), temporary ? .Temporary : nil, ifNotExists),
+            create(View.identifier, tableName(), temporary ? .temporary : nil, ifNotExists),
             Expression<Void>(literal: "AS"),
             query
         ]
@@ -513,8 +513,8 @@ private func reference(_ primary: (QueryType, Expressible)) -> Expressible {
 
 private enum Modifier : String {
 
-    case Unique = "UNIQUE"
+    case unique = "UNIQUE"
 
-    case Temporary = "TEMPORARY"
+    case temporary = "TEMPORARY"
 
 }


### PR DESCRIPTION
Looks like some of the docs might have gotten left behind in the great renaming