### PR TITLE
Fix demonstration of how to trace SQL statements in docs

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -1578,7 +1578,7 @@ We can log SQL using the database’s `trace` function.
 
 ``` swift
 #if DEBUG
-    db.trace(print)
+    db.trace { print($0) }
 #endif
 ```
 


### PR DESCRIPTION
The old way shown causes a build error in swift 3 (XCode8):

  Ambiguous reference to member 'print(_:separator:terminator:)'
