### PR TITLE
Fix OS X database path

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -251,7 +251,7 @@ On OS X, you can use your app’s **Application Support** directory:
 ``` swift
 var path = NSSearchPathForDirectoriesInDomains(
     .applicationSupportDirectory, .userDomainMask, true
-).first! + Bundle.main.bundleIdentifier!
+).first! + "/" + Bundle.main.bundleIdentifier!
 
 // create parent directory iff it doesn’t exist
 try FileManager.default.createDirectoryAtPath(


### PR DESCRIPTION
Currently, the `path` is set to: 

```
/Users/avi/Library/Application SupportMyIdentifier
```

This PR fixes it and adds the missing slash:

```
/Users/avi/Library/Application Support/MyIdentifier
```