### PR TITLE
add support for ORDER and LIMIT on UPDATE and DELETE

### DIFF
--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -648,7 +648,9 @@ extension QueryType {
             tableName(),
             Expression<Void>(literal: "SET"),
             ", ".join(values.map { " = ".join([$0.column, $0.value]) }),
-            whereClause
+            whereClause,
+            orderClause,
+            limitOffsetClause
         ]
 
         return Update(" ".join(clauses.flatMap { $0 }).expression)
@@ -660,7 +662,9 @@ extension QueryType {
         let clauses: [Expressible?] = [
             Expression<Void>(literal: "DELETE FROM"),
             tableName(),
-            whereClause
+            whereClause,
+            orderClause,
+            limitOffsetClause
         ]
 
         return Delete(" ".join(clauses.flatMap { $0 }).expression)

--- a/Tests/SQLiteTests/QueryTests.swift
+++ b/Tests/SQLiteTests/QueryTests.swift
@@ -245,10 +245,24 @@ class QueryTests : XCTestCase {
         )
     }
 
+    func test_update_compilesUpdateLimitOrderExpression() {
+        AssertSQL(
+            "UPDATE \"users\" SET \"age\" = 30 ORDER BY \"id\" LIMIT 1",
+            users.order(id).limit(1).update(age <- 30)
+        )
+    }
+
     func test_delete_compilesDeleteExpression() {
         AssertSQL(
             "DELETE FROM \"users\" WHERE (\"id\" = 1)",
             users.filter(id == 1).delete()
+        )
+    }
+
+    func test_delete_compilesDeleteLimitOrderExpression() {
+        AssertSQL(
+            "DELETE FROM \"users\" ORDER BY \"id\" LIMIT 1",
+            users.order(id).limit(1).delete()
         )
     }
 


### PR DESCRIPTION
SQLite supports this syntax when compiled with the `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` compile option, which Apple apparently does on at least iOS 10.3 and macOS 10.12. Even if it isn't compiled with this option, if the library user specifies an order and limit it gets silently ignored as-is, which seems dangerous.

this fixes #657 

