### PR TITLE
Do not use .characters on Strings

### DIFF
--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -577,7 +577,7 @@ public final class Connection {
             } else if let result = result as? Int64 {
                 sqlite3_result_int64(context, result)
             } else if let result = result as? String {
-                sqlite3_result_text(context, result, Int32(result.characters.count), SQLITE_TRANSIENT)
+                sqlite3_result_text(context, result, Int32(result.count), SQLITE_TRANSIENT)
             } else if result == nil {
                 sqlite3_result_null(context)
             } else {

--- a/Sources/SQLite/Typed/Expression.swift
+++ b/Sources/SQLite/Typed/Expression.swift
@@ -77,7 +77,7 @@ extension Expressible {
     public func asSQL() -> String {
         let expressed = expression
         var idx = 0
-        return expressed.template.characters.reduce("") { template, character in
+        return expressed.template.reduce("") { template, character in
             let transcoded: String
             
             if character == "?" {

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -938,7 +938,7 @@ extension Connection {
     private func columnNamesForQuery(_ query: QueryType) throws -> [String: Int] {
         var (columnNames, idx) = ([String: Int](), 0)
         column: for each in query.clauses.select.columns {
-            var names = each.expression.template.characters.split { $0 == "." }.map(String.init)
+            var names = each.expression.template.split { $0 == "." }.map(String.init)
             let column = names.removeLast()
             let namespace = names.joined(separator: ".")
             

--- a/Sources/SQLite/Typed/Schema.swift
+++ b/Sources/SQLite/Typed/Schema.swift
@@ -148,7 +148,7 @@ extension Table {
     fileprivate func indexName(_ columns: [Expressible]) -> Expressible {
         let string = (["index", clauses.from.name, "on"] + columns.map { $0.expression.template }).joined(separator: " ").lowercased()
 
-        let index = string.characters.reduce("") { underscored, character in
+        let index = string.reduce("") { underscored, character in
             guard character != "\"" else {
                 return underscored
             }

--- a/Tests/SQLiteTests/ConnectionTests.swift
+++ b/Tests/SQLiteTests/ConnectionTests.swift
@@ -369,7 +369,7 @@ class ConnectionTests : SQLiteTestCase {
     }
 
     func test_interrupt_interruptsLongRunningQuery() {
-        try! InsertUsers("abcdefghijklmnopqrstuvwxyz".characters.map { String($0) })
+        try! InsertUsers("abcdefghijklmnopqrstuvwxyz".map { String($0) })
         db.createFunction("sleep") { args in
             usleep(UInt32((args[0] as? Double ?? Double(args[0] as? Int64 ?? 1)) * 1_000_000))
             return nil


### PR DESCRIPTION
Prevents warnings in Xcode 9.1 by adopting proper Swift 4 syntax.

cc @noahsmartin @fdiaz