### PR TITLE
Resolved the warning that was raised because "characters" of a "String" has been deprecated.

### DIFF
--- a/Sources/SQLite/Helpers.swift
+++ b/Sources/SQLite/Helpers.swift
@@ -56,7 +56,7 @@ let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 extension String {
 
     func quote(_ mark: Character = "\"") -> String {
-        let escaped = characters.reduce("") { string, character in
+        let escaped = reduce("") { string, character in
             string + (character == mark ? "\(mark)\(mark)" : "\(character)")
         }
         return "\(mark)\(escaped)\(mark)"


### PR DESCRIPTION
Resolved a warning that was caused dude to "characters" deprecation in "String"