### PR TITLE
Add Array Unterface for createIndex(_:unique:ifNotExists:)

### DIFF
--- a/Sources/SQLite/Typed/Schema.swift
+++ b/Sources/SQLite/Typed/Schema.swift
@@ -126,16 +126,20 @@ extension Table {
     }
 
     // MARK: - CREATE INDEX
-
-    public func createIndex(_ columns: Expressible..., unique: Bool = false, ifNotExists: Bool = false) -> String {
+    
+    public func createIndex(_ columns: [Expressible], unique: Bool = false, ifNotExists: Bool = false) -> String {
         let clauses: [Expressible?] = [
             create("INDEX", indexName(columns), unique ? .unique : nil, ifNotExists),
             Expression<Void>(literal: "ON"),
             tableName(qualified: false),
             "".wrap(columns) as Expression<Void>
         ]
-
+        
         return " ".join(clauses.flatMap { $0 }).asSQL()
+    }
+
+    public func createIndex(_ columns: Expressible..., unique: Bool = false, ifNotExists: Bool = false) -> String {
+        return createIndex(columns, unique: unique, ifNotExists: ifNotExists)
     }
 
     // MARK: - DROP INDEX

--- a/Tests/SQLiteTests/SchemaTests.swift
+++ b/Tests/SQLiteTests/SchemaTests.swift
@@ -741,6 +741,22 @@ class SchemaTests : XCTestCase {
             "CREATE UNIQUE INDEX IF NOT EXISTS \"main\".\"index_table_on_int64\" ON \"table\" (\"int64\")",
             qualifiedTable.createIndex(int64, unique: true, ifNotExists: true)
         )
+        XCTAssertEqual(
+            "CREATE UNIQUE INDEX \"index_table_on_int64\" ON \"table\" (\"int64\")",
+            table.createIndex([int64], unique: true)
+        )
+        XCTAssertEqual(
+            "CREATE INDEX IF NOT EXISTS \"index_table_on_int64\" ON \"table\" (\"int64\")",
+            table.createIndex([int64], ifNotExists: true)
+        )
+        XCTAssertEqual(
+            "CREATE UNIQUE INDEX IF NOT EXISTS \"index_table_on_int64\" ON \"table\" (\"int64\")",
+            table.createIndex([int64], unique: true, ifNotExists: true)
+        )
+        XCTAssertEqual(
+            "CREATE UNIQUE INDEX IF NOT EXISTS \"main\".\"index_table_on_int64\" ON \"table\" (\"int64\")",
+            qualifiedTable.createIndex([int64], unique: true, ifNotExists: true)
+        )
     }
 
     func test_dropIndex_compilesCreateIndexExpression() {


### PR DESCRIPTION
How about adding array interface for createIndex(_:unique:ifNotExists:), in addition to variadic interface?
Inside variadic function the type of the parameter is Array. But it does not accept Array Type.
Isn't it inconvenient a little bit in using it inside some functions like below?

```swift
import SQLite

var table: Table
func Hoge(numberColumns: Int...) {
...
table.createIndex(numberColumns) // Error because of variadic.
...
}
```

Sincerely,