### PR TITLE
Add `and` and `or` functions

### DIFF
--- a/Sources/SQLite/Helpers.swift
+++ b/Sources/SQLite/Helpers.swift
@@ -73,7 +73,11 @@ extension String {
     }
 
     func infix<T>(_ lhs: Expressible, _ rhs: Expressible, wrap: Bool = true) -> Expression<T> {
-        let expression = Expression<T>(" \(self) ".join([lhs, rhs]).expression)
+        return infix([lhs, rhs], wrap: wrap)
+    }
+    
+    func infix<T>(_ terms: [Expressible], wrap: Bool = true) -> Expression<T> {
+        let expression = Expression<T>(" \(self) ".join(terms).expression)
         guard wrap else {
             return expression
         }

--- a/Sources/SQLite/Typed/Operators.swift
+++ b/Sources/SQLite/Typed/Operators.swift
@@ -547,6 +547,12 @@ public func ~=<V : Value>(lhs: PartialRangeFrom<V>, rhs: Expression<V?>) -> Expr
 
 // MARK: -
 
+public func and(_ terms: Expression<Bool>...) -> Expression<Bool> {
+    return "AND".infix(terms)
+}
+public func and(_ terms: [Expression<Bool>]) -> Expression<Bool> {
+    return "AND".infix(terms)
+}
 public func &&(lhs: Expression<Bool>, rhs: Expression<Bool>) -> Expression<Bool> {
     return Operator.and.infix(lhs, rhs)
 }
@@ -572,6 +578,12 @@ public func &&(lhs: Bool, rhs: Expression<Bool?>) -> Expression<Bool?> {
     return Operator.and.infix(lhs, rhs)
 }
 
+public func or(_ terms: Expression<Bool>...) -> Expression<Bool> {
+    return "OR".infix(terms)
+}
+public func or(_ terms: [Expression<Bool>]) -> Expression<Bool> {
+    return "OR".infix(terms)
+}
 public func ||(lhs: Expression<Bool>, rhs: Expression<Bool>) -> Expression<Bool> {
     return Operator.or.infix(lhs, rhs)
 }

--- a/Tests/SQLiteTests/OperatorsTests.swift
+++ b/Tests/SQLiteTests/OperatorsTests.swift
@@ -290,6 +290,16 @@ class OperatorsTests : XCTestCase {
         AssertSQL("(1 AND \"bool\")", true && bool)
         AssertSQL("(1 AND \"boolOptional\")", true && boolOptional)
     }
+    
+    func test_andFunction_withBooleanExpressions_buildsCompoundExpression() {
+        AssertSQL("(\"bool\" AND \"bool\" AND \"bool\")", and([bool, bool, bool]))
+        AssertSQL("(\"bool\" AND \"bool\")", and([bool, bool]))
+        AssertSQL("(\"bool\")", and([bool]))
+        
+        AssertSQL("(\"bool\" AND \"bool\" AND \"bool\")", and(bool, bool, bool))
+        AssertSQL("(\"bool\" AND \"bool\")", and(bool, bool))
+        AssertSQL("(\"bool\")", and(bool))
+    }
 
     func test_doubleOrOperator_withBooleanExpressions_buildsCompoundExpression() {
         AssertSQL("(\"bool\" OR \"bool\")", bool || bool)
@@ -300,6 +310,16 @@ class OperatorsTests : XCTestCase {
         AssertSQL("(\"boolOptional\" OR 1)", boolOptional || true)
         AssertSQL("(1 OR \"bool\")", true || bool)
         AssertSQL("(1 OR \"boolOptional\")", true || boolOptional)
+    }
+    
+    func test_orFunction_withBooleanExpressions_buildsCompoundExpression() {
+        AssertSQL("(\"bool\" OR \"bool\" OR \"bool\")", or([bool, bool, bool]))
+        AssertSQL("(\"bool\" OR \"bool\")", or([bool, bool]))
+        AssertSQL("(\"bool\")", or([bool]))
+        
+        AssertSQL("(\"bool\" OR \"bool\" OR \"bool\")", or(bool, bool, bool))
+        AssertSQL("(\"bool\" OR \"bool\")", or(bool, bool))
+        AssertSQL("(\"bool\")", or(bool))
     }
 
     func test_unaryNotOperator_withBooleanExpressions_buildsNotExpression() {


### PR DESCRIPTION
When you're programmatically building a query to execute, you have times where you build a variable number of clauses by which you filter a table. There isn't a great way to turn an `Array<Expression<Bool>>` into an `Expression<Bool>`, short of making a large `(a AND (b AND (c AND (d AND e))))` expression.

`and` and `or` fix this by allowing you to turn an `Array<Expression<Bool>>` directly into a lower-complexity clause: `(a AND b AND c AND d AND e)`