### PR TITLE
Fix for non-framework build

### DIFF
--- a/Sources/SQLite/Typed/Coding.swift
+++ b/Sources/SQLite/Typed/Coding.swift
@@ -184,7 +184,7 @@ fileprivate class SQLiteEncoder: Encoder {
         }
     }
 
-    fileprivate var setters: [SQLite.Setter] = []
+    fileprivate var setters: [Setter] = []
     let codingPath: [CodingKey] = []
     let userInfo: [CodingUserInfoKey: Any]
 


### PR DESCRIPTION
Fixed a mistype that prevented building SQLite.swift as non-framework sources.

Steps to reproduce:
- download the source
- create new XCode project
- add SQLite.swift sources inside new project (just sources, not the actual .xcodeproj file)
- build.

As result: sources are built as is and no framework is created -> reference to `SQLite.` becomes invalid. 
Keeping in mind that `Setter` is referenced in this file earlier I assume this is a mistype.