### PR TITLE
fix markdown table formatting

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -718,7 +718,7 @@ try db.transaction {
 | `<<=`    | `Int -> Int`       |
 | `>>=`    | `Int -> Int`       |
 | `&=`     | `Int -> Int`       |
-| `||=`    | `Int -> Int`       |
+| `\|\|=`  | `Int -> Int`       |
 | `^=`     | `Int -> Int`       |
 | `+=`     | `String -> String` |
 
@@ -954,7 +954,7 @@ equate or compare different types will prevent compilation.
 | `<=`  | `Comparable -> Bool`             | `<=`           |
 | `~=`  | `(Interval, Comparable) -> Bool` | `BETWEEN`      |
 | `&&`  | `Bool -> Bool`                   | `AND`          |
-| `||`  | `Bool -> Bool`                   | `OR`           |
+| `\|\|`| `Bool -> Bool`                   | `OR`           |
 
 > *When comparing against `nil`, SQLite.swift will use `IS` and `IS NOT`
 > accordingly.
@@ -1586,8 +1586,8 @@ arithmetic, bitwise operations, and concatenation.
 | `<<`  | `Int -> Int`                     | `<<`     |
 | `>>`  | `Int -> Int`                     | `>>`     |
 | `&`   | `Int -> Int`                     | `&`      |
-| `|`   | `Int -> Int`                     | `|`      |
-| `+`   | `String -> String`               | `||`     |
+| `\|`  | `Int -> Int`                     | `\|`     |
+| `+`   | `String -> String`               | `\|\|`   |
 
 > _Note:_ SQLite.swift also defines a bitwise XOR operator, `^`, which
 > expands the expression `lhs ^ rhs` to `~(lhs & rhs) & (lhs | rhs)`.


### PR DESCRIPTION
tables containing `|` are breaking github markdown formatter when they are not escaped.