### PR TITLE
updated Bridging header to be compatible with SQLCipher 4.0.0 pod

### DIFF
--- a/Sources/SQLiteObjc/include/SQLite-Bridging.h
+++ b/Sources/SQLiteObjc/include/SQLite-Bridging.h
@@ -23,8 +23,7 @@
 //
 
 @import Foundation;
-
-#import "sqlite3.h"
+@import SQLCipher;
 
 NS_ASSUME_NONNULL_BEGIN
 typedef NSString * _Nullable (^_SQLiteTokenizerNextCallback)(const char *input, int *inputOffset, int *inputLength);


### PR DESCRIPTION
until this change, I was not able to install SQLite.swift with Xcode 10.1 via
``` pod 'SQLite.swift/SQLCipher'

SQLCipher dependency pod version resolved - 4.0.0

the build failed with error:

error: include of non-modular header inside framework module 'SQLite.SQLite_Bridging': '<project-path>/Pods/SQLCipher/sqlite3.h'
#import "sqlite3.h"

however, I'm not sure this change does not affect Carthage or SPM installation.