### PR TITLE
fix xcode-10.2 issues

### DIFF
--- a/Sources/SQLite/Helpers.swift
+++ b/Sources/SQLite/Helpers.swift
@@ -98,18 +98,6 @@ extension String {
 
 }
 
-func infix<T>(_ lhs: Expressible, _ rhs: Expressible, wrap: Bool = true, function: String = #function) -> Expression<T> {
-    return function.infix(lhs, rhs, wrap: wrap)
-}
-
-func wrap<T>(_ expression: Expressible, function: String = #function) -> Expression<T> {
-    return function.wrap(expression)
-}
-
-func wrap<T>(_ expressions: [Expressible], function: String = #function) -> Expression<T> {
-    return function.wrap(", ".join(expressions))
-}
-
 func transcode(_ literal: Binding?) -> String {
     guard let literal = literal else { return "NULL" }
 

--- a/Sources/SQLite/Typed/AggregateFunctions.swift
+++ b/Sources/SQLite/Typed/AggregateFunctions.swift
@@ -48,7 +48,7 @@ extension ExpressionType where UnderlyingType : Value {
     /// - Returns: A copy of the expression wrapped with the `count` aggregate
     ///   function.
     public var count: Expression<Int> {
-        return wrap(self)
+        return "count".wrap(self)
     }
 
 }
@@ -79,7 +79,7 @@ extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.Wr
     /// - Returns: A copy of the expression wrapped with the `count` aggregate
     ///   function.
     public var count: Expression<Int> {
-        return wrap(self)
+        return "count".wrap(self)
     }
 
 }
@@ -96,7 +96,7 @@ extension ExpressionType where UnderlyingType : Value, UnderlyingType.Datatype :
     /// - Returns: A copy of the expression wrapped with the `max` aggregate
     ///   function.
     public var max: Expression<UnderlyingType?> {
-        return wrap(self)
+        return "max".wrap(self)
     }
 
     /// Builds a copy of the expression wrapped with the `min` aggregate
@@ -109,7 +109,7 @@ extension ExpressionType where UnderlyingType : Value, UnderlyingType.Datatype :
     /// - Returns: A copy of the expression wrapped with the `min` aggregate
     ///   function.
     public var min: Expression<UnderlyingType?> {
-        return wrap(self)
+        return "min".wrap(self)
     }
 
 }
@@ -126,7 +126,7 @@ extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.Wr
     /// - Returns: A copy of the expression wrapped with the `max` aggregate
     ///   function.
     public var max: Expression<UnderlyingType> {
-        return wrap(self)
+        return "max".wrap(self)
     }
 
     /// Builds a copy of the expression wrapped with the `min` aggregate
@@ -139,7 +139,7 @@ extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.Wr
     /// - Returns: A copy of the expression wrapped with the `min` aggregate
     ///   function.
     public var min: Expression<UnderlyingType> {
-        return wrap(self)
+        return "min".wrap(self)
     }
 
 }
@@ -169,7 +169,7 @@ extension ExpressionType where UnderlyingType : Value, UnderlyingType.Datatype :
     /// - Returns: A copy of the expression wrapped with the `min` aggregate
     ///   function.
     public var sum: Expression<UnderlyingType?> {
-        return wrap(self)
+        return "sum".wrap(self)
     }
 
     /// Builds a copy of the expression wrapped with the `total` aggregate
@@ -182,7 +182,7 @@ extension ExpressionType where UnderlyingType : Value, UnderlyingType.Datatype :
     /// - Returns: A copy of the expression wrapped with the `min` aggregate
     ///   function.
     public var total: Expression<Double> {
-        return wrap(self)
+        return "total".wrap(self)
     }
 
 }
@@ -212,7 +212,7 @@ extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.Wr
     /// - Returns: A copy of the expression wrapped with the `min` aggregate
     ///   function.
     public var sum: Expression<UnderlyingType> {
-        return wrap(self)
+        return "sum".wrap(self)
     }
 
     /// Builds a copy of the expression wrapped with the `total` aggregate
@@ -225,7 +225,7 @@ extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.Wr
     /// - Returns: A copy of the expression wrapped with the `min` aggregate
     ///   function.
     public var total: Expression<Double> {
-        return wrap(self)
+        return "total".wrap(self)
     }
 
 }
@@ -233,7 +233,7 @@ extension ExpressionType where UnderlyingType : _OptionalType, UnderlyingType.Wr
 extension ExpressionType where UnderlyingType == Int {
 
     static func count(_ star: Star) -> Expression<UnderlyingType> {
-        return wrap(star(nil, nil))
+        return "count".wrap(star(nil, nil))
     }
 
 }

--- a/Sources/SQLite/Typed/CoreFunctions.swift
+++ b/Sources/SQLite/Typed/CoreFunctions.swift
@@ -68,9 +68,9 @@ extension ExpressionType where UnderlyingType == Double {
     /// - Returns: A copy of the expression wrapped with the `round` function.
     public func round(_ precision: Int? = nil) -> Expression<UnderlyingType> {
         guard let precision = precision else {
-            return wrap([self])
+            return "round".wrap([self])
         }
-        return wrap([self, Int(precision)])
+        return "round".wrap([self, Int(precision)])
     }
 
 }
@@ -88,9 +88,9 @@ extension ExpressionType where UnderlyingType == Double? {
     /// - Returns: A copy of the expression wrapped with the `round` function.
     public func round(_ precision: Int? = nil) -> Expression<UnderlyingType> {
         guard let precision = precision else {
-            return wrap(self)
+            return "round".wrap(self)
         }
-        return wrap([self, Int(precision)])
+        return "round".wrap([self, Int(precision)])
     }
 
 }
@@ -143,7 +143,7 @@ extension ExpressionType where UnderlyingType == Data {
     ///
     /// - Returns: A copy of the expression wrapped with the `length` function.
     public var length: Expression<Int> {
-        return wrap(self)
+        return "length".wrap(self)
     }
 
 }
@@ -158,7 +158,7 @@ extension ExpressionType where UnderlyingType == Data? {
     ///
     /// - Returns: A copy of the expression wrapped with the `length` function.
     public var length: Expression<Int?> {
-        return wrap(self)
+        return "length".wrap(self)
     }
 
 }
@@ -173,7 +173,7 @@ extension ExpressionType where UnderlyingType == String {
     ///
     /// - Returns: A copy of the expression wrapped with the `length` function.
     public var length: Expression<Int> {
-        return wrap(self)
+        return "length".wrap(self)
     }
 
     /// Builds a copy of the expression wrapped with the `lower` function.
@@ -317,9 +317,9 @@ extension ExpressionType where UnderlyingType == String {
     /// - Returns: A copy of the expression wrapped with the `ltrim` function.
     public func ltrim(_ characters: Set<Character>? = nil) -> Expression<UnderlyingType> {
         guard let characters = characters else {
-            return wrap(self)
+            return "ltrim".wrap(self)
         }
-        return wrap([self, String(characters)])
+        return "ltrim".wrap([self, String(characters)])
     }
 
     /// Builds a copy of the expression wrapped with the `rtrim` function.
@@ -335,9 +335,9 @@ extension ExpressionType where UnderlyingType == String {
     /// - Returns: A copy of the expression wrapped with the `rtrim` function.
     public func rtrim(_ characters: Set<Character>? = nil) -> Expression<UnderlyingType> {
         guard let characters = characters else {
-            return wrap(self)
+            return "rtrim".wrap(self)
         }
-        return wrap([self, String(characters)])
+        return "rtrim".wrap([self, String(characters)])
     }
 
     /// Builds a copy of the expression wrapped with the `trim` function.
@@ -353,9 +353,9 @@ extension ExpressionType where UnderlyingType == String {
     /// - Returns: A copy of the expression wrapped with the `trim` function.
     public func trim(_ characters: Set<Character>? = nil) -> Expression<UnderlyingType> {
         guard let characters = characters else {
-            return wrap([self])
+            return "trim".wrap([self])
         }
-        return wrap([self, String(characters)])
+        return "trim".wrap([self, String(characters)])
     }
 
     /// Builds a copy of the expression wrapped with the `replace` function.
@@ -398,7 +398,7 @@ extension ExpressionType where UnderlyingType == String? {
     ///
     /// - Returns: A copy of the expression wrapped with the `length` function.
     public var length: Expression<Int?> {
-        return wrap(self)
+        return "length".wrap(self)
     }
 
     /// Builds a copy of the expression wrapped with the `lower` function.
@@ -542,9 +542,9 @@ extension ExpressionType where UnderlyingType == String? {
     /// - Returns: A copy of the expression wrapped with the `ltrim` function.
     public func ltrim(_ characters: Set<Character>? = nil) -> Expression<UnderlyingType> {
         guard let characters = characters else {
-            return wrap(self)
+            return "ltrim".wrap(self)
         }
-        return wrap([self, String(characters)])
+        return "ltrim".wrap([self, String(characters)])
     }
 
     /// Builds a copy of the expression wrapped with the `rtrim` function.
@@ -560,9 +560,9 @@ extension ExpressionType where UnderlyingType == String? {
     /// - Returns: A copy of the expression wrapped with the `rtrim` function.
     public func rtrim(_ characters: Set<Character>? = nil) -> Expression<UnderlyingType> {
         guard let characters = characters else {
-            return wrap(self)
+            return "rtrim".wrap(self)
         }
-        return wrap([self, String(characters)])
+        return "rtrim".wrap([self, String(characters)])
     }
 
     /// Builds a copy of the expression wrapped with the `trim` function.
@@ -578,9 +578,9 @@ extension ExpressionType where UnderlyingType == String? {
     /// - Returns: A copy of the expression wrapped with the `trim` function.
     public func trim(_ characters: Set<Character>? = nil) -> Expression<UnderlyingType> {
         guard let characters = characters else {
-            return wrap(self)
+            return "trim".wrap(self)
         }
-        return wrap([self, String(characters)])
+        return "trim".wrap([self, String(characters)])
     }
 
     /// Builds a copy of the expression wrapped with the `replace` function.

--- a/Sources/SQLite/Typed/Operators.swift
+++ b/Sources/SQLite/Typed/Operators.swift
@@ -53,237 +53,237 @@ public func +(lhs: String, rhs: Expression<String?>) -> Expression<String?> {
 // MARK: -
 
 public func +<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "+".infix(lhs, rhs)
 }
 public func +<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "+".infix(lhs, rhs)
 }
 public func +<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "+".infix(lhs, rhs)
 }
 public func +<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "+".infix(lhs, rhs)
 }
 public func +<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "+".infix(lhs, rhs)
 }
 public func +<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "+".infix(lhs, rhs)
 }
 public func +<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "+".infix(lhs, rhs)
 }
 public func +<V: Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "+".infix(lhs, rhs)
 }
 
 public func -<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "-".infix(lhs, rhs)
 }
 public func -<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "-".infix(lhs, rhs)
 }
 public func -<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "-".infix(lhs, rhs)
 }
 public func -<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "-".infix(lhs, rhs)
 }
 public func -<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "-".infix(lhs, rhs)
 }
 public func -<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "-".infix(lhs, rhs)
 }
 public func -<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "-".infix(lhs, rhs)
 }
 public func -<V: Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "-".infix(lhs, rhs)
 }
 
 public func *<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "*".infix(lhs, rhs)
 }
 public func *<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "*".infix(lhs, rhs)
 }
 public func *<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "*".infix(lhs, rhs)
 }
 public func *<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "*".infix(lhs, rhs)
 }
 public func *<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "*".infix(lhs, rhs)
 }
 public func *<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "*".infix(lhs, rhs)
 }
 public func *<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "*".infix(lhs, rhs)
 }
 public func *<V: Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "*".infix(lhs, rhs)
 }
 
 public func /<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "/".infix(lhs, rhs)
 }
 public func /<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "/".infix(lhs, rhs)
 }
 public func /<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "/".infix(lhs, rhs)
 }
 public func /<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "/".infix(lhs, rhs)
 }
 public func /<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "/".infix(lhs, rhs)
 }
 public func /<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "/".infix(lhs, rhs)
 }
 public func /<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "/".infix(lhs, rhs)
 }
 public func /<V: Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return infix(lhs, rhs)
+    return "/".infix(lhs, rhs)
 }
 
 public prefix func -<V : Value>(rhs: Expression<V>) -> Expression<V> where V.Datatype : Number {
-    return wrap(rhs)
+    return "-".wrap(rhs)
 }
 public prefix func -<V : Value>(rhs: Expression<V?>) -> Expression<V?> where V.Datatype : Number {
-    return wrap(rhs)
+    return "-".wrap(rhs)
 }
 
 // MARK: -
 
 public func %<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "%".infix(lhs, rhs)
 }
 public func %<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "%".infix(lhs, rhs)
 }
 public func %<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "%".infix(lhs, rhs)
 }
 public func %<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "%".infix(lhs, rhs)
 }
 public func %<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "%".infix(lhs, rhs)
 }
 public func %<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "%".infix(lhs, rhs)
 }
 public func %<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "%".infix(lhs, rhs)
 }
 public func %<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "%".infix(lhs, rhs)
 }
 
 public func <<<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "<<".infix(lhs, rhs)
 }
 public func <<<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "<<".infix(lhs, rhs)
 }
 public func <<<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "<<".infix(lhs, rhs)
 }
 public func <<<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "<<".infix(lhs, rhs)
 }
 public func <<<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "<<".infix(lhs, rhs)
 }
 public func <<<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "<<".infix(lhs, rhs)
 }
 public func <<<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "<<".infix(lhs, rhs)
 }
 public func <<<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "<<".infix(lhs, rhs)
 }
 
 public func >><V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return ">>".infix(lhs, rhs)
 }
 public func >><V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return ">>".infix(lhs, rhs)
 }
 public func >><V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return ">>".infix(lhs, rhs)
 }
 public func >><V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return ">>".infix(lhs, rhs)
 }
 public func >><V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return ">>".infix(lhs, rhs)
 }
 public func >><V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return ">>".infix(lhs, rhs)
 }
 public func >><V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return ">>".infix(lhs, rhs)
 }
 public func >><V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return ">>".infix(lhs, rhs)
 }
 
 public func &<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "&".infix(lhs, rhs)
 }
 public func &<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "&".infix(lhs, rhs)
 }
 public func &<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "&".infix(lhs, rhs)
 }
 public func &<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "&".infix(lhs, rhs)
 }
 public func &<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "&".infix(lhs, rhs)
 }
 public func &<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "&".infix(lhs, rhs)
 }
 public func &<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "&".infix(lhs, rhs)
 }
 public func &<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "&".infix(lhs, rhs)
 }
 
 public func |<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "|".infix(lhs, rhs)
 }
 public func |<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "|".infix(lhs, rhs)
 }
 public func |<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "|".infix(lhs, rhs)
 }
 public func |<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "|".infix(lhs, rhs)
 }
 public func |<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "|".infix(lhs, rhs)
 }
 public func |<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "|".infix(lhs, rhs)
 }
 public func |<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "|".infix(lhs, rhs)
 }
 public func |<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return infix(lhs, rhs)
+    return "|".infix(lhs, rhs)
 }
 
 public func ^<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
@@ -312,10 +312,10 @@ public func ^<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<V?> where V.
 }
 
 public prefix func ~<V : Value>(rhs: Expression<V>) -> Expression<V> where V.Datatype == Int64 {
-    return wrap(rhs)
+    return "~".wrap(rhs)
 }
 public prefix func ~<V : Value>(rhs: Expression<V?>) -> Expression<V?> where V.Datatype == Int64 {
-    return wrap(rhs)
+    return "~".wrap(rhs)
 }
 
 // MARK: -
@@ -348,130 +348,130 @@ public func ==<V : Value>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool?> whe
 }
 
 public func !=<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
-    return infix(lhs, rhs)
+    return "!=".infix(lhs, rhs)
 }
 public func !=<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Equatable {
-    return infix(lhs, rhs)
+    return "!=".infix(lhs, rhs)
 }
 public func !=<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool?> where V.Datatype : Equatable {
-    return infix(lhs, rhs)
+    return "!=".infix(lhs, rhs)
 }
 public func !=<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Equatable {
-    return infix(lhs, rhs)
+    return "!=".infix(lhs, rhs)
 }
 public func !=<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Equatable {
-    return infix(lhs, rhs)
+    return "!=".infix(lhs, rhs)
 }
 public func !=<V : Value>(lhs: Expression<V?>, rhs: V?) -> Expression<Bool?> where V.Datatype : Equatable {
     guard let rhs = rhs else { return "IS NOT".infix(lhs, Expression<V?>(value: nil)) }
-    return infix(lhs, rhs)
+    return "!=".infix(lhs, rhs)
 }
 public func !=<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
-    return infix(lhs, rhs)
+    return "!=".infix(lhs, rhs)
 }
 public func !=<V : Value>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Equatable {
     guard let lhs = lhs else { return "IS NOT".infix(Expression<V?>(value: nil), rhs) }
-    return infix(lhs, rhs)
+    return "!=".infix(lhs, rhs)
 }
 
 public func ><V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">".infix(lhs, rhs)
 }
 public func ><V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">".infix(lhs, rhs)
 }
 public func ><V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">".infix(lhs, rhs)
 }
 public func ><V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">".infix(lhs, rhs)
 }
 public func ><V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">".infix(lhs, rhs)
 }
 public func ><V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">".infix(lhs, rhs)
 }
 public func ><V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">".infix(lhs, rhs)
 }
 public func ><V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">".infix(lhs, rhs)
 }
 
 public func >=<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">=".infix(lhs, rhs)
 }
 public func >=<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">=".infix(lhs, rhs)
 }
 public func >=<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">=".infix(lhs, rhs)
 }
 public func >=<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">=".infix(lhs, rhs)
 }
 public func >=<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">=".infix(lhs, rhs)
 }
 public func >=<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">=".infix(lhs, rhs)
 }
 public func >=<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">=".infix(lhs, rhs)
 }
 public func >=<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return ">=".infix(lhs, rhs)
 }
 
 public func <<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<".infix(lhs, rhs)
 }
 public func <<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<".infix(lhs, rhs)
 }
 public func <<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<".infix(lhs, rhs)
 }
 public func <<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<".infix(lhs, rhs)
 }
 public func <<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<".infix(lhs, rhs)
 }
 public func <<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<".infix(lhs, rhs)
 }
 public func <<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<".infix(lhs, rhs)
 }
 public func <<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<".infix(lhs, rhs)
 }
 
 public func <=<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<=".infix(lhs, rhs)
 }
 public func <=<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<=".infix(lhs, rhs)
 }
 public func <=<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<=".infix(lhs, rhs)
 }
 public func <=<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<=".infix(lhs, rhs)
 }
 public func <=<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<=".infix(lhs, rhs)
 }
 public func <=<V : Value>(lhs: Expression<V?>, rhs: V) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<=".infix(lhs, rhs)
 }
 public func <=<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<=".infix(lhs, rhs)
 }
 public func <=<V : Value>(lhs: V, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Comparable {
-    return infix(lhs, rhs)
+    return "<=".infix(lhs, rhs)
 }
 
 public func ~=<V : Value>(lhs: ClosedRange<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable & Value {


### PR DESCRIPTION
resolves #888 

> In Xcode 10.2 beta 4 the macro `#function` shows a different behaviour. As SQLite.swift relies on `#function` in different subroutines for the composition of SQLite queries, several bugs linked to invalid SQLite statements seem to be introduced.

I replaced all the `#function` magic by static strings.