### PR TITLE
Remove warnings about 'public' modifier is redundant

### DIFF
--- a/Sources/SQLite/Typed/CustomFunctions.swift
+++ b/Sources/SQLite/Typed/CustomFunctions.swift
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 //
 
-public extension Connection {
+extension Connection {
 
     /// Creates or redefines a custom SQL function.
     ///


### PR DESCRIPTION
When compiling SQLite with the newest versions of Xcode 14 warnings are generated stating that:
```
'public' modifier is redundant for instance method declared in a public extension
```

This PR fixes that warning.

Alternatively, we could remove the `public` modifier from the 14 function declarations below, but as the extension contains both `public` and `fileprivate` functions I think it is more appropriate to remove the top-level public modifier on the extension itself. 

I think this was implemented in [SR-8453](https://bugs.swift.org/browse/SR-8453) and became a warning starting with Xcode 10.2, but this should not break compilation for any version of Xcode capable of compiling code for Swift 4.2 that this project is currently using.