### PR TITLE
If not on Swift 5+, use old datatypeValue implementation

### DIFF
--- a/Sources/SQLite/Foundation.swift
+++ b/Sources/SQLite/Foundation.swift
@@ -35,9 +35,15 @@ extension Data : Value {
     }
 
     public var datatypeValue: Blob {
+        #if swift(>=5.0)
         return withUnsafeBytes { (pointer: UnsafeRawBufferPointer) -> Blob in
             return Blob(bytes: pointer.baseAddress!, length: count)
         }
+        #else
+        return withUnsafeBytes { (pointer: UnsafePointer<UInt8>) -> Blob in
+            return Blob(bytes: pointer, length: count)
+        }
+        #endif
     }
 
 }


### PR DESCRIPTION
This fixes compiler errors when using the latest release of SQLite with Swift 4.2/Xcode 10.1 (as discussed in this issue: https://github.com/stephencelis/SQLite.swift/issues/920)

I notice the test suite is set up to only build and run with SWIFT_VERSION=5.0 To verify this fix, I manually changed the version to 4.2 and ran it in Xcode 10.1. However it might be desirable to also duplicate all test targets and have them also run on 4.2 if continued support of the previous version is desirable.