### PR TITLE
Fix building with standalone sqlite3 >= 3.30.0

### DIFF
--- a/SQLite.swift.podspec
+++ b/SQLite.swift.podspec
@@ -50,7 +50,8 @@ Pod::Spec.new do |s|
     ss.private_header_files = 'Sources/SQLiteObjc/*.h'
 
     ss.xcconfig = {
-      'OTHER_SWIFT_FLAGS' => '$(inherited) -DSQLITE_SWIFT_STANDALONE'
+      'OTHER_SWIFT_FLAGS' => '$(inherited) -DSQLITE_SWIFT_STANDALONE',
+      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SQLITE_SWIFT_STANDALONE=1'
     }
     ss.dependency 'sqlite3'
 

--- a/Sources/SQLiteObjc/include/SQLiteObjc.h
+++ b/Sources/SQLiteObjc/include/SQLiteObjc.h
@@ -23,7 +23,11 @@
 //
 
 @import Foundation;
+#if defined(SQLITE_SWIFT_STANDALONE)
+@import sqlite3;
+#else
 @import SQLite3;
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 typedef NSString * _Nullable (^_SQLiteTokenizerNextCallback)(const char *input, int *inputOffset, int *inputLength);


### PR DESCRIPTION
## Problem
When using `SQLite.swift/standalone` with `sqlite3` pod version >= 3.30.0, attempting to build the project results in "ambiguous use" warning in Xcode pointing [here](https://github.com/stephencelis/SQLite.swift/blob/0a9893ec030501a3956bee572d6b4fdd3ae158a1/Sources/SQLite/Core/Connection.swift#L590).

## Solution
SQLite 3.30.0 changed the definition of SQLITE_DETERMINISTIC:
```diff
-#define SQLITE_DETERMINISTIC    0x800
+#define SQLITE_DETERMINISTIC    0x000000800
```

Meaning that the (older) system sqlite3 library and the pod have different definitions, even though they're the same value.

We've been importing the system SQLite3 module in `SQLiteObjc.h` even when linking against standalone sqlite.

I added a check to `SQLiteObjc.h` to import the sqlite3 pod when we're using it, instead of always importing the system module.

This leads to there being only one definition in scope.