### PR TITLE
Swift 5.1 Property Wrapper:  Expressed

### DIFF
--- a/Sources/SQLite/Typed/Expressed.swift
+++ b/Sources/SQLite/Typed/Expressed.swift
@@ -1,13 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by 游宗諭 on 2019/12/26.
-//
-
 import Foundation
-
-
 
 #if swift(>=5.1)
 /// A type that Expression a property marked with an attribute.
@@ -21,10 +12,10 @@ import Foundation
 	
 	public var wrappedValue: Value
 	///Creates a publisher with the provided initial value.
-	init(wrappedValue: Value, _ key: String) {
-		projectedValue =  Expression<Value>(key)
+	public init(wrappedValue: Value, _ key: String, bindings: [Binding?] = []) {
+		projectedValue =  Expression<Value>(key, bindings)
 		self.wrappedValue = wrappedValue
 	}
-	internal var setter:Setter { projectedValue <- wrappedValue }
+	public var setter:Setter { projectedValue <- wrappedValue }
 }
 #endif

--- a/Sources/SQLite/Typed/Expressed.swift
+++ b/Sources/SQLite/Typed/Expressed.swift
@@ -1,0 +1,30 @@
+//
+//  File.swift
+//  
+//
+//  Created by 游宗諭 on 2019/12/26.
+//
+
+import Foundation
+
+
+
+#if swift(>=5.1)
+/// A type that Expression a property marked with an attribute.
+///```swift
+///@Expressed("id") var id = UUID().string
+///```
+///
+@propertyWrapper public struct Expressed<Value> where Value: SQLite.Value {
+	///The property for which this instance exposes a Expression.
+	public let projectedValue:Expression<Value>
+	
+	public var wrappedValue: Value
+	///Creates a publisher with the provided initial value.
+	init(wrappedValue: Value, _ key: String) {
+		projectedValue =  Expression<Value>(key)
+		self.wrappedValue = wrappedValue
+	}
+	internal var setter:Setter { projectedValue <- wrappedValue }
+}
+#endif

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -672,7 +672,32 @@ extension QueryType {
             query.expression
         ]).expression)
     }
-
+	#if swift(>=5.1)
+	func insert<V>(_ value: Expressed<V>, _ more: Expressed<V>...) -> Insert where V: Value {
+		
+		insert([value.setter] + more.map{$0.setter})
+	}
+	//
+	// MARK: INSERT
+	public func insert<V>(_ values: [Expressed<V>]) -> Insert {
+		return insert(nil, values)
+	}
+	
+	public func insert<V>(or onConflict: OnConflict, _ values: Expressed<V>...) -> Insert {
+		return insert(or: onConflict, values)
+	}
+	
+	public func insert<V>(or onConflict: OnConflict, _ values: [Expressed<V>]) -> Insert {
+		return insert(onConflict, values)
+	}
+	
+	fileprivate func insert<V>(_ or: OnConflict?, _ expresseds: [Expressed<V>]) -> Insert {
+		let values:[Setter] = expresseds.map{ expressed in
+			expressed.setter
+		}
+		return insert(or, values)
+	}
+	#endif
     // MARK: UPDATE
 
     public func update(_ values: Setter...) -> Update {

--- a/Tests/SQLiteTests/ExpressedTests.swift
+++ b/Tests/SQLiteTests/ExpressedTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import SQLite
+
+class ExpressedTests : XCTestCase {
+	@Expressed("id") var propertyID:String = "1"
+	func testExpressed() {
+		let expression: Expression<String> = $propertyID
+	}
+}

--- a/Tests/SQLiteTests/ExpressedTests.swift
+++ b/Tests/SQLiteTests/ExpressedTests.swift
@@ -2,8 +2,4 @@ import XCTest
 import SQLite
 
 class ExpressedTests : XCTestCase {
-	@Expressed("id") var propertyID:String = "1"
-	func testExpressed() {
-		let expression: Expression<String> = $propertyID
-	}
 }


### PR DESCRIPTION
Consider of [SE-0258](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md)

```swift
@Expressed("id") var id:String = UUID().string
```
## Help Wanted 
1. `Expressed` Maybe not a proper name, help wanted.
2. Still working on tests, don't know how to test for a property wrapper, Equable?
3. Edit README and Documentation.