### PR TITLE
Crash in Prepare

### DIFF
--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -923,9 +923,18 @@ extension Connection {
 
         let columnNames = try columnNamesForQuery(query)
         
-        let rows = try statement.failableNext().map { Row(columnNames, $0) }
         return AnySequence {
-            AnyIterator { rows }
+            return AnyIterator {
+                do {
+                    if let model = try statement.failableNext() {
+                        return Row(columnNames,model)
+                    }
+                } catch {
+                    return nil
+                }
+            
+                return nil
+            }
         }
     }
     

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -922,9 +922,10 @@ extension Connection {
         let statement = try prepare(expression.template, expression.bindings)
 
         let columnNames = try columnNamesForQuery(query)
-
+        
+        let rows = try statement.failableNext().map { Row(columnNames, $0) }
         return AnySequence {
-            AnyIterator { statement.next().map { Row(columnNames, $0) } }
+            AnyIterator { rows }
         }
     }
     


### PR DESCRIPTION
There is a crash observed in prepare, changed the code to use statement.failableNext and modified AnyIterator appropriately

Crash Log 
0  libswiftCore.dylib             0x10c23a1a4 specialized _assertionFailure(_:_:file:line:flags:) + 42360
1  libswiftCore.dylib             0x10c28fc48 swift_unexpectedError + 280
2  SQLite                         0x10b1f0b5c $S6SQLite10ConnectionC7prepareys11AnySequenceVyAA3RowVGAA9QueryType_pKFs0D8IteratorVyAHGycfU_AHSgycfU_ + 204
3  SQLite                         0x10b1fbcd0 $S6SQLite3RowVSgIego_ADIegr_TRTA + 24
4  libswiftCore.dylib             0x10c21e320 _ClosureBasedIterator.next() + 93472
5  libswiftCore.dylib             0x10c21e4ac _IteratorBox.next() + 93868
6  libswiftCore.dylib             0x10c0e0050 AnyIterator.next() + 237412
7  libswiftCore.dylib             0x10c21e4ac _IteratorBox.next() + 93868