### PR TITLE
fix namespace check when joining tables

### DIFF
--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -958,14 +958,16 @@ extension Connection {
                 select.clauses.select = (false, [Expression<Void>(literal: "*") as Expressible])
                 let queries = [select] + query.clauses.join.map { $0.query }
                 if !namespace.isEmpty {
+                    let tableNames = queries.map({ $0.tableName().expression.template })
+                    if !tableNames.contains(namespace) {
+                        throw QueryError.noSuchTable(name: namespace)
+                    }
                     for q in queries {
                         if q.tableName().expression.template == namespace {
                             try expandGlob(true)(q)
                             continue column
                         }
-                        throw QueryError.noSuchTable(name: namespace)
                     }
-                    throw QueryError.noSuchTable(name: namespace)
                 }
                 for q in queries {
                     try expandGlob(query.clauses.join.count > 0)(q)


### PR DESCRIPTION
The unit test is reproducing the issue. Even if the query is correct, a
"table not found error" was returned.

This PR is based on https://github.com/stephencelis/SQLite.swift/pull/916

Fix https://github.com/stephencelis/SQLite.swift/issues/777