### PR TITLE
Always start the iterator at the same location

### DIFF
--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -922,9 +922,10 @@ extension Connection {
         let statement = try prepare(expression.template, expression.bindings)
 
         let columnNames = try columnNamesForQuery(query)
+        let element = try statement.failableNext()
 
         return AnySequence {
-            AnyIterator { statement.next().map { Row(columnNames, $0) } }
+            AnyIterator { element.map { Row(columnNames, $0) } }
         }
     }
     


### PR DESCRIPTION
I was looking at a crash that happens when `statement.next()` is called. I have not gotten to the bottom of it, but I came across this code that doesn't seem to do what it intends. Indeed it seems that calling the iterator several time will not do the same thing:
```swift
let result = self.db.prepare(query)
result.forEach { ... }
// The second call will loop over the rows from a different element?
result.forEach { ... }
```