### PR TITLE
Added === as explicit “IS” operator for expressions

### DIFF
--- a/Sources/SQLite/Typed/Operators.swift
+++ b/Sources/SQLite/Typed/Operators.swift
@@ -432,6 +432,34 @@ public func !=<V : Value>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool?> whe
     return Operator.neq.infix(lhs, rhs)
 }
 
+public func !==<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+    return "IS NOT".infix(lhs, rhs)
+}
+public func !==<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Equatable {
+    return "IS NOT".infix(lhs, rhs)
+}
+public func !==<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool?> where V.Datatype : Equatable {
+    return "IS NOT".infix(lhs, rhs)
+}
+public func !==<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Equatable {
+    return "IS NOT".infix(lhs, rhs)
+}
+public func !==<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Equatable {
+    return "IS NOT".infix(lhs, rhs)
+}
+public func !==<V : Value>(lhs: Expression<V?>, rhs: V?) -> Expression<Bool?> where V.Datatype : Equatable {
+    guard let rhs = rhs else { return "IS NOT".infix(lhs, Expression<V?>(value: nil)) }
+    return "IS NOT".infix(lhs, rhs)
+}
+public func !==<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+    return "IS NOT".infix(lhs, rhs)
+}
+public func !==<V : Value>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Equatable {
+    guard let lhs = lhs else { return "IS NOT".infix(Expression<V?>(value: nil), rhs) }
+    return "IS NOT".infix(lhs, rhs)
+}
+
+
 public func ><V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Comparable {
     return Operator.gt.infix(lhs, rhs)
 }

--- a/Sources/SQLite/Typed/Operators.swift
+++ b/Sources/SQLite/Typed/Operators.swift
@@ -378,6 +378,33 @@ public func ==<V : Value>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool?> whe
     return Operator.eq.infix(lhs, rhs)
 }
 
+public func ===<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+    return "IS".infix(lhs, rhs)
+}
+public func ===<V : Value>(lhs: Expression<V>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Equatable {
+    return "IS".infix(lhs, rhs)
+}
+public func ===<V : Value>(lhs: Expression<V?>, rhs: Expression<V>) -> Expression<Bool?> where V.Datatype : Equatable {
+    return "IS".infix(lhs, rhs)
+}
+public func ===<V : Value>(lhs: Expression<V?>, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Equatable {
+    return "IS".infix(lhs, rhs)
+}
+public func ===<V : Value>(lhs: Expression<V>, rhs: V) -> Expression<Bool> where V.Datatype : Equatable {
+    return "IS".infix(lhs, rhs)
+}
+public func ===<V : Value>(lhs: Expression<V?>, rhs: V?) -> Expression<Bool?> where V.Datatype : Equatable {
+    guard let rhs = rhs else { return "IS".infix(lhs, Expression<V?>(value: nil)) }
+    return "IS".infix(lhs, rhs)
+}
+public func ===<V : Value>(lhs: V, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
+    return "IS".infix(lhs, rhs)
+}
+public func ===<V : Value>(lhs: V?, rhs: Expression<V?>) -> Expression<Bool?> where V.Datatype : Equatable {
+    guard let lhs = lhs else { return "IS".infix(Expression<V?>(value: nil), rhs) }
+    return "IS".infix(lhs, rhs)
+}
+
 public func !=<V : Value>(lhs: Expression<V>, rhs: Expression<V>) -> Expression<Bool> where V.Datatype : Equatable {
     return Operator.neq.infix(lhs, rhs)
 }

--- a/Tests/SQLiteTests/OperatorsTests.swift
+++ b/Tests/SQLiteTests/OperatorsTests.swift
@@ -200,6 +200,20 @@ class OperatorsTests : XCTestCase {
        AssertSQL("(\"boolOptional\" IS NULL)", boolOptional === nil)
        AssertSQL("(NULL IS \"boolOptional\")", nil === boolOptional)
     }
+    
+    func test_isNotOperator_withEquatableExpressions_buildsBooleanExpression() {
+        AssertSQL("(\"bool\" IS NOT \"bool\")", bool !== bool)
+        AssertSQL("(\"bool\" IS NOT \"boolOptional\")", bool !== boolOptional)
+        AssertSQL("(\"boolOptional\" IS NOT \"bool\")", boolOptional !== bool)
+        AssertSQL("(\"boolOptional\" IS NOT \"boolOptional\")", boolOptional !== boolOptional)
+        AssertSQL("(\"bool\" IS NOT 1)", bool !== true)
+        AssertSQL("(\"boolOptional\" IS NOT 1)", boolOptional !== true)
+        AssertSQL("(1 IS NOT \"bool\")", true !== bool)
+        AssertSQL("(1 IS NOT \"boolOptional\")", true !== boolOptional)
+
+        AssertSQL("(\"boolOptional\" IS NOT NULL)", boolOptional !== nil)
+        AssertSQL("(NULL IS NOT \"boolOptional\")", nil !== boolOptional)
+     }
 
     func test_inequalityOperator_withEquatableExpressions_buildsBooleanExpression() {
         AssertSQL("(\"bool\" != \"bool\")", bool != bool)

--- a/Tests/SQLiteTests/OperatorsTests.swift
+++ b/Tests/SQLiteTests/OperatorsTests.swift
@@ -187,6 +187,20 @@ class OperatorsTests : XCTestCase {
         AssertSQL("(NULL IS \"boolOptional\")", nil == boolOptional)
     }
 
+    func test_isOperator_withEquatableExpressions_buildsBooleanExpression() {
+       AssertSQL("(\"bool\" IS \"bool\")", bool === bool)
+       AssertSQL("(\"bool\" IS \"boolOptional\")", bool === boolOptional)
+       AssertSQL("(\"boolOptional\" IS \"bool\")", boolOptional === bool)
+       AssertSQL("(\"boolOptional\" IS \"boolOptional\")", boolOptional === boolOptional)
+       AssertSQL("(\"bool\" IS 1)", bool === true)
+       AssertSQL("(\"boolOptional\" IS 1)", boolOptional === true)
+       AssertSQL("(1 IS \"bool\")", true === bool)
+       AssertSQL("(1 IS \"boolOptional\")", true === boolOptional)
+
+       AssertSQL("(\"boolOptional\" IS NULL)", boolOptional === nil)
+       AssertSQL("(NULL IS \"boolOptional\")", nil === boolOptional)
+    }
+
     func test_inequalityOperator_withEquatableExpressions_buildsBooleanExpression() {
         AssertSQL("(\"bool\" != \"bool\")", bool != bool)
         AssertSQL("(\"bool\" != \"boolOptional\")", bool != boolOptional)


### PR DESCRIPTION
Sometimes, you explicitly want the "IS" operator, unlike the automatic logic that sometimes uses the IS operator when using the == operator with expressions.

Possible solution for feature request stephencelis/SQLite.swift#1003

- Added === as explicit “IS” operator for expressions.
- Added tests for === operator.
