### PR TITLE
Adding a `vacuum()` fonction to `Connection`

### DIFF
--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -252,6 +252,17 @@ public final class Connection {
     @discardableResult public func run(_ statement: String, _ bindings: [String: Binding?]) throws -> Statement {
         return try prepare(statement).run(bindings)
     }
+    
+    // MARK: - VACUUM
+    
+    /// Run a vacuum on the database
+    ///
+    /// - Throws: `Result.Error` if query execution fails.
+    ///
+    /// - Returns: The statement.
+    @discardableResult public func vacuum() throws -> Statement {
+        return try run("VACUUM")
+    }
 
     // MARK: - Scalar
 

--- a/Tests/SQLiteTests/ConnectionTests.swift
+++ b/Tests/SQLiteTests/ConnectionTests.swift
@@ -111,6 +111,10 @@ class ConnectionTests : SQLiteTestCase {
         try! db.run("SELECT * FROM users WHERE admin = $admin", ["$admin": 0])
         AssertSQL("SELECT * FROM users WHERE admin = 0", 4)
     }
+    
+    func test_vacuum() {
+        try! db.vacuum()
+    }
 
     func test_scalar_preparesRunsAndReturnsScalarValues() {
         XCTAssertEqual(0, try! db.scalar("SELECT count(*) FROM users WHERE admin = 0") as? Int64)


### PR DESCRIPTION
Fixes #1047 

Usage:
```swift
try connection.vacuum()
```