### PR TITLE
Reverting a change in `FailableIterator`

### DIFF
--- a/Sources/SQLite/Core/Statement.swift
+++ b/Sources/SQLite/Core/Statement.swift
@@ -207,7 +207,7 @@ public protocol FailableIterator: IteratorProtocol {
 
 extension FailableIterator {
     public func next() -> Element? {
-        // swiftlint:disable:next force_cast
+        // swiftlint:disable:next force_try
         try! failableNext()
     }
 }


### PR DESCRIPTION
Linked to #1030 

Note: we need to explain how to let people handle errors using `failableNext` directly:

```swift
do {
    while let row = try iterator.failableNext() {
        // Handle row
    }
} catch {
    // Handle error
}
```