### PR TITLE
Fix/column alias

### DIFF
--- a/Sources/SQLite/Typed/Expression.swift
+++ b/Sources/SQLite/Typed/Expression.swift
@@ -106,6 +106,9 @@ extension ExpressionType {
         " ".join([self, Expression<Void>(literal: "DESC")])
     }
 
+    public func alias(name:String) -> Expressible {
+        return " ".join([self, Expression<Void>(literal: "AS \(name)")])
+    }
 }
 
 extension ExpressionType where UnderlyingType: Value {

--- a/Sources/SQLite/Typed/Expression.swift
+++ b/Sources/SQLite/Typed/Expression.swift
@@ -107,7 +107,7 @@ extension ExpressionType {
     }
 
     public func alias(_ aliasName: String) -> Expressible {
-        return " ".join([self, Expression<Void>(literal: "AS \(aliasName)")])
+        return " ".join([self, Expression<Void>(literal: "AS \"\(aliasName)\"")])
     }
 }
 

--- a/Sources/SQLite/Typed/Expression.swift
+++ b/Sources/SQLite/Typed/Expression.swift
@@ -106,8 +106,8 @@ extension ExpressionType {
         " ".join([self, Expression<Void>(literal: "DESC")])
     }
 
-    public func alias(name:String) -> Expressible {
-        return " ".join([self, Expression<Void>(literal: "AS \(name)")])
+    public func alias(_ aliasName: String) -> Expressible {
+        return " ".join([self, Expression<Void>(literal: "AS \(aliasName)")])
     }
 }
 

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1228,21 +1228,21 @@ public enum OnConflict: String {
 
 public struct QueryClauses {
 
-    var select = (distinct: false, columns: [Expression<Void>(literal: "*") as Expressible])
+    public internal(set) var select = (distinct: false, columns: [Expression<Void>(literal: "*") as Expressible])
 
-    var from: (name: String, alias: String?, database: String?)
+    public internal(set) var from: (name: String, alias: String?, database: String?)
 
-    var join = [(type: JoinType, query: QueryType, condition: Expressible)]()
+    public internal(set) var join = [(type: JoinType, query: QueryType, condition: Expressible)]()
 
-    var filters: Expression<Bool?>?
+    public internal(set) var filters: Expression<Bool?>?
 
-    var group: (by: [Expressible], having: Expression<Bool?>?)?
+    public internal(set) var group: (by: [Expressible], having: Expression<Bool?>?)?
 
-    var order = [Expressible]()
+    public internal(set) var order = [Expressible]()
 
-    var limit: (length: Int, offset: Int?)?
+    public internal(set) var limit: (length: Int, offset: Int?)?
 
-    var union = [QueryType]()
+    public internal(set) var union = [QueryType]()
 
     fileprivate init(_ name: String, alias: String?, database: String?) {
         from = (name, alias, database)

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1169,7 +1169,7 @@ public struct Row {
         }
 
         guard let idx = columnNames[column.template] else {
-            let similar = Array(columnNames.keys).filter { $0.hasSuffix(".\(column.template)") }
+            let similar = Array(columnNames.keys).filter { $0.hasSuffix(".\(column.template)") || $0.hasSuffix(" AS \(column.template)") }
 
             switch similar.count {
             case 0:


### PR DESCRIPTION
Fixes https://github.com/stephencelis/SQLite.swift/issues/225 by allowing columns to be aliased. Also allows QueryClauses to be accessed publicly, though only modified internally.