### PR TITLE
Fix/public row

### DIFF
--- a/Sources/SQLite/Typed/Expression.swift
+++ b/Sources/SQLite/Typed/Expression.swift
@@ -106,6 +106,9 @@ extension ExpressionType {
         " ".join([self, Expression<Void>(literal: "DESC")])
     }
 
+    public func alias(_ aliasName: String) -> Expressible {
+        return " ".join([self, Expression<Void>(literal: "AS \"\(aliasName)\"")])
+    }
 }
 
 extension ExpressionType where UnderlyingType: Value {

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1169,7 +1169,7 @@ public struct Row {
         }
 
         guard let idx = columnNames[column.template] else {
-            let similar = Array(columnNames.keys).filter { $0.hasSuffix(".\(column.template)") }
+            let similar = Array(columnNames.keys).filter { $0.hasSuffix(".\(column.template)") || $0.hasSuffix(" AS \(column.template)") }
 
             switch similar.count {
             case 0:
@@ -1228,21 +1228,21 @@ public enum OnConflict: String {
 
 public struct QueryClauses {
 
-    var select = (distinct: false, columns: [Expression<Void>(literal: "*") as Expressible])
+    public internal(set) var select = (distinct: false, columns: [Expression<Void>(literal: "*") as Expressible])
 
-    var from: (name: String, alias: String?, database: String?)
+    public internal(set) var from: (name: String, alias: String?, database: String?)
 
-    var join = [(type: JoinType, query: QueryType, condition: Expressible)]()
+    public internal(set) var join = [(type: JoinType, query: QueryType, condition: Expressible)]()
 
-    var filters: Expression<Bool?>?
+    public internal(set) var filters: Expression<Bool?>?
 
-    var group: (by: [Expressible], having: Expression<Bool?>?)?
+    public internal(set) var group: (by: [Expressible], having: Expression<Bool?>?)?
 
-    var order = [Expressible]()
+    public internal(set) var order = [Expressible]()
 
-    var limit: (length: Int, offset: Int?)?
+    public internal(set) var limit: (length: Int, offset: Int?)?
 
-    var union = [QueryType]()
+    public internal(set) var union = [QueryType]()
 
     fileprivate init(_ name: String, alias: String?, database: String?) {
         from = (name, alias, database)

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1137,7 +1137,7 @@ public struct Row {
 
     fileprivate let values: [Binding?]
 
-    internal init(_ columnNames: [String: Int], _ values: [Binding?]) {
+    public init(_ columnNames: [String: Int], _ values: [Binding?]) {
         self.columnNames = columnNames
         self.values = values
     }


### PR DESCRIPTION
Allows `Row` objects to be created publicly. This makes it easy to convert statements prepared from raw SQL and run with Connection.run() into the same shape as Connection.prepare(anyTableObject)