### PR TITLE
Added supported iOS version to the Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "SQLite.swift",
+    platforms: [
+        .iOS(.v9),
+        .macOS(.v10_15),
+        .watchOS(.v3),
+        .tvOS(.v9)
+    ],
     products: [
         .library(
             name: "SQLite",


### PR DESCRIPTION
Currently the Package.swift lacks a definition of the supported iOS version. I'm not sure if there is a conflict with the #ifdef for the linux version of this package.