### PR TITLE
Align platform versions in SPM manifest and Xcode project

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,12 +52,6 @@ package.dependencies = [.package(url: "https://github.com/stephencelis/CSQLite.g
 package.targets = [
     .target(
         name: "SQLite",
-        platforms: [
-            .iOS(.v9),
-            .macOS(.v10_15),
-            .watchOS(.v3),
-            .tvOS(.v9)
-        ],
         dependencies: [.product(name: "CSQLite", package: "CSQLite")],
         exclude: ["Extensions/FTS4.swift", "Extensions/FTS5.swift"]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "SQLite.swift",
+    platforms: [
+        .iOS(.v9),
+        .macOS(.v10_15),
+        .watchOS(.v3),
+        .tvOS(.v9)
+    ],
     products: [
         .library(
             name: "SQLite",
@@ -46,6 +52,12 @@ package.dependencies = [.package(url: "https://github.com/stephencelis/CSQLite.g
 package.targets = [
     .target(
         name: "SQLite",
+        platforms: [
+            .iOS(.v9),
+            .macOS(.v10_15),
+            .watchOS(.v3),
+            .tvOS(.v9)
+        ],
         dependencies: [.product(name: "CSQLite", package: "CSQLite")],
         exclude: ["Extensions/FTS4.swift", "Extensions/FTS5.swift"]
     ),

--- a/SQLite.xcodeproj/project.pbxproj
+++ b/SQLite.xcodeproj/project.pbxproj
@@ -1099,7 +1099,6 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
-				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -1121,7 +1120,6 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
-				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -1135,7 +1133,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
-				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -1149,7 +1146,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
-				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -1173,7 +1169,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Debug;
 		};
@@ -1197,7 +1192,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Release;
 		};
@@ -1259,8 +1253,10 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
+				TVOS_DEPLOYMENT_TARGET = 9.1;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Debug;
 		};
@@ -1315,9 +1311,11 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
+				TVOS_DEPLOYMENT_TARGET = 9.1;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Release;
 		};
@@ -1334,7 +1332,6 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/SQLite/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 0.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLite;
@@ -1358,7 +1355,6 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/SQLite/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 0.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLite;

--- a/Tests/SPM/Package.swift
+++ b/Tests/SPM/Package.swift
@@ -5,6 +5,12 @@ import PackageDescription
 
 let package = Package(
     name: "test",
+    platforms: [
+        .iOS(.v9),
+        .macOS(.v10_15),
+        .watchOS(.v3),
+        .tvOS(.v9)
+    ],
     dependencies: [
         // for testing from same repository
         .package(path: "../..")


### PR DESCRIPTION
#### This PR:
1. Adds platform versions to the SPM manifest; we discovered this was missing while debugging https://github.com/apollographql/apollo-ios/pull/2015. This addition should allow SPM to correctly resolve deployment targets.
2. Moves the Xcode deployment versions configuration from each target to the project level. There is some personal preference to this change but I do also believe there is value in being able to set all deployment versions in one place (project) vs. the individual targets where it's easy to miss versions not being the same. I also changed the tvOS target to match Cocoapods, which specifies `9.1`.

_I saw that https://github.com/stephencelis/SQLite.swift/pull/1083 already attempted this but that PR seems dead and the fork has also been deleted. If this one is merged you can close #1083._

#### Question:
1. Is there any particular reason why SQLite.swift `0.13.0` bumped the macOS deployment target to `10.15`? It seems at odds with the iOS deployment target of `9.0` which would have greater support for older APIs.