### PR TITLE
UUID Fix

### DIFF
--- a/Sources/SQLite/Typed/Coding.swift
+++ b/Sources/SQLite/Typed/Coding.swift
@@ -207,6 +207,8 @@ private class SQLiteEncoder: Encoder {
                 encoder.setters.append(Expression(key.stringValue) <- data)
             } else if let date = value as? Date {
                 encoder.setters.append(Expression(key.stringValue) <- date.datatypeValue)
+            }else if let uuid = value as? UUID {
+                encoder.setters.append(Expression(key.stringValue) <- uuid.uuidString)
             } else {
                 let encoded = try JSONEncoder().encode(value)
                 let string = String(data: encoded, encoding: .utf8)


### PR DESCRIPTION
Inserting a UUID as Expression<UUID> resulted in escaped quotes on either side of the uuidString and thus actual quotes stored inside the DB.  When retrieving a row, the result of UUID(uudiString:) returns null when a uuidString with quotes on either side is given.
This appears to be an issue with JSONEncoder.
Fix pre-empts JSONEncoder and inserts a proper uuidString without escaped quotes on either side.
