### PR TITLE
Improve performance of prefixed column resolution

### DIFF
--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1169,18 +1169,18 @@ public struct Row {
         }
 
         guard let idx = columnNames[column.template] else {
-            func similar(_ s: String) -> Bool {
-                return s.hasSuffix(".\(column.template)")
+            func similar(_ name: String) -> Bool {
+                return name.hasSuffix(".\(column.template)")
             }
-            
+
             guard let firstIndex = columnNames.firstIndex(where: { similar($0.key) }) else {
                 throw QueryError.noSuchColumn(name: column.template, columns: columnNames.keys.sorted())
             }
-            
+
             let secondIndex = columnNames
                 .suffix(from: columnNames.index(after: firstIndex))
                 .firstIndex(where: { similar($0.key) })
-            
+
             guard secondIndex == nil else {
                 throw QueryError.ambiguousColumn(
                     name: column.template,

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1169,16 +1169,25 @@ public struct Row {
         }
 
         guard let idx = columnNames[column.template] else {
-            let similar = Array(columnNames.keys).filter { $0.hasSuffix(".\(column.template)") }
-
-            switch similar.count {
-            case 0:
-                throw QueryError.noSuchColumn(name: column.template, columns: columnNames.keys.sorted())
-            case 1:
-                return valueAtIndex(columnNames[similar[0]]!)
-            default:
-                throw QueryError.ambiguousColumn(name: column.template, similar: similar)
+            func match(_ s: String) -> Bool {
+                return s.hasSuffix(".\(column.template)")
             }
+            
+            guard let firstIndex = columnNames.firstIndex(where: { match($0.key) }) else {
+                throw QueryError.noSuchColumn(name: column.template, columns: columnNames.keys.sorted())
+            }
+            
+            let secondIndex = columnNames
+                .suffix(from: columnNames.index(after: firstIndex))
+                .firstIndex(where: { match($0.key) })
+            
+            guard secondIndex == nil else {
+                throw QueryError.ambiguousColumn(
+                    name: column.template,
+                    similar: columnNames.keys.filter(match).sorted()
+                )
+            }
+            return valueAtIndex(columnNames[firstIndex].value)
         }
 
         return valueAtIndex(idx)

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1169,22 +1169,22 @@ public struct Row {
         }
 
         guard let idx = columnNames[column.template] else {
-            func match(_ s: String) -> Bool {
+            func similar(_ s: String) -> Bool {
                 return s.hasSuffix(".\(column.template)")
             }
             
-            guard let firstIndex = columnNames.firstIndex(where: { match($0.key) }) else {
+            guard let firstIndex = columnNames.firstIndex(where: { similar($0.key) }) else {
                 throw QueryError.noSuchColumn(name: column.template, columns: columnNames.keys.sorted())
             }
             
             let secondIndex = columnNames
                 .suffix(from: columnNames.index(after: firstIndex))
-                .firstIndex(where: { match($0.key) })
+                .firstIndex(where: { similar($0.key) })
             
             guard secondIndex == nil else {
                 throw QueryError.ambiguousColumn(
                     name: column.template,
-                    similar: columnNames.keys.filter(match).sorted()
+                    similar: columnNames.keys.filter(similar).sorted()
                 )
             }
             return valueAtIndex(columnNames[firstIndex].value)


### PR DESCRIPTION
For issue #1109 
- Previously this allocated arrays every time it was accessed. It will now only allocate in one of the error cases.
- It also keeps track of the columnName index for both key and value so it doesn't need to look it up twice.