### PR TITLE
WIP: Demo Codable Enum issue

### DIFF
--- a/Tests/SQLiteTests/QueryIntegrationTests.swift
+++ b/Tests/SQLiteTests/QueryIntegrationTests.swift
@@ -106,6 +106,23 @@ class QueryIntegrationTests: SQLiteTestCase {
         XCTAssertNil(values[0].sub?.sub)
     }
 
+    func test_select_codable_camelCase() throws {
+        let table = Table("codable_enum")
+        let column = Expression<StringEnum>("camelCaseString")
+        try db.run(table.create { builder in
+            builder.column(column)
+        })
+        let value = CamelCaseStruct(camelCaseString: .one)
+        try db.run(table.insert(value))
+        try db.run(table.insert(column <- .one))
+
+        let rows = try db.prepare(table)
+        let values: [CamelCaseStruct] = try rows.map({ try $0.decode() })
+        XCTAssertEqual(values.count, 2)
+        XCTAssertEqual(values[0].camelCaseString, .one)
+        XCTAssertEqual(values[1].camelCaseString, .one)
+    }
+
     func test_scalar() {
         XCTAssertEqual(0, try! db.scalar(users.count))
         XCTAssertEqual(false, try! db.scalar(users.exists))

--- a/Tests/SQLiteTests/TestHelpers.swift
+++ b/Tests/SQLiteTests/TestHelpers.swift
@@ -140,3 +140,24 @@ class TestCodable: Codable, Equatable {
         lhs.sub == rhs.sub
     }
 }
+
+enum StringEnum: String {
+    case one
+    case nope
+}
+extension StringEnum: Codable {}
+struct CamelCaseStruct: Codable {
+    var camelCaseString: StringEnum
+}
+extension StringEnum: Value {
+    public typealias Datatype = String
+    public static var declaredDatatype: String = String.declaredDatatype
+
+    public static func fromDatatypeValue(_ datatypeValue: String) -> StringEnum {
+        return StringEnum(rawValue: datatypeValue) ?? .nope
+    }
+
+    public var datatypeValue: String {
+        return self.rawValue
+    }
+}


### PR DESCRIPTION
This is not the MR to merge in the current, but more like an issue with submitted demo test case.

The problem: Codable Enum works fine only if saved via Encodable insert, but breaks if I insert column values directly. Compare:

```swift
try db.run(table.insert(value)) //this one will read just fine
// INSERT INTO "codable_camel_case" ("camelCaseString") VALUES ('"one"')
try db.run(table.insert(column <- .one)) //this one produces runtime error upon decode
// INSERT INTO "codable_camel_case" ("camelCaseString") VALUES ('one')
```

I did implement conformance to `Value` protocol, as you can see in the code, but it seems `fromDatatypeValue()` function is never used. Instead, it seems to treat it as a JSON, but the second inserted value is of course no valid JSON