### PR TITLE
Improve string quote performance

### DIFF
--- a/Sources/SQLite/Helpers.swift
+++ b/Sources/SQLite/Helpers.swift
@@ -54,12 +54,17 @@ extension Optional: _OptionalType {
 let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 extension String {
-
     func quote(_ mark: Character = "\"") -> String {
-        let escaped = reduce("") { string, character in
-            string + (character == mark ? "\(mark)\(mark)" : "\(character)")
+        var quoted = ""
+        quoted.append(mark)
+        for character in self {
+            quoted.append(character)
+            if character == mark {
+                quoted.append(character)
+            }
         }
-        return "\(mark)\(escaped)\(mark)"
+        quoted.append(mark)
+        return quoted
     }
 
     func join(_ expressions: [Expressible]) -> Expressible {


### PR DESCRIPTION
The `quote` function was showing up in my instruments profile.  The current implementation requires an allocation of a one or more strings at every step of the `reduce`. This version adds one character at a time and relies on the geometric growth of the string itself. I personally think it's a little clearer as well.

I considered adding `reserveCapacity` to the beginning, but that might be a bit of a micro-optimization.
