### PR TITLE
Adding public method to reset a prepared statement

### DIFF
--- a/Sources/SQLite/Core/Statement.swift
+++ b/Sources/SQLite/Core/Statement.swift
@@ -185,7 +185,11 @@ public final class Statement {
         try connection.sync { try connection.check(sqlite3_step(handle)) == SQLITE_ROW }
     }
 
-    fileprivate func reset(clearBindings shouldClear: Bool = true) {
+    public func reset() {
+        reset(clearBindings: true)
+    }
+
+    fileprivate func reset(clearBindings shouldClear: Bool) {
         sqlite3_reset(handle)
         if shouldClear { sqlite3_clear_bindings(handle) }
     }

--- a/Tests/SQLiteTests/StatementTests.swift
+++ b/Tests/SQLiteTests/StatementTests.swift
@@ -34,4 +34,61 @@ class StatementTests: SQLiteTestCase {
 
         XCTAssertEqual(names.map({ "\($0)@example.com" }), emails.sorted())
     }
+
+    /// Check that a statement reset will close the implicit transaction, allowing wal file to checkpoint
+    func test_reset_statement() throws {
+        // Remove old test db if any
+        let path = "\(NSTemporaryDirectory())/SQLite.swift Tests.sqlite3"
+        try? FileManager.default.removeItem(atPath: path)
+        try? FileManager.default.removeItem(atPath: path + "-shm")
+        try? FileManager.default.removeItem(atPath: path + "-wal")
+
+        // create new db on disk in wal mode
+        let db = try Connection(.uri(path))
+        let url = URL(fileURLWithPath: db.description)
+        XCTAssertEqual(url.lastPathComponent, "SQLite.swift Tests.sqlite3")
+        try db.run("PRAGMA journal_mode=WAL;")
+
+        // create users table
+        try db.execute("""
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                email TEXT NOT NULL UNIQUE,
+                age INTEGER,
+                salary REAL,
+                admin BOOLEAN NOT NULL DEFAULT 0 CHECK (admin IN (0, 1)),
+                manager_id INTEGER,
+                created_at DATETIME,
+                FOREIGN KEY(manager_id) REFERENCES users(id)
+            )
+            """
+        )
+
+        // insert single row
+        try db.run("INSERT INTO \"users\" (email, age, admin) values (?, ?, ?)",
+                   "alice@example.com", 1.datatypeValue, false.datatypeValue)
+
+        // prepare a statement and read a single row. This will incremeent the cursor which
+        // prevents the implicit transaction from closing.
+        // https://www.sqlite.org/lang_transaction.html#implicit_versus_explicit_transactions
+        let statement = try db.prepare("SELECT email FROM users")
+        XCTAssert(try statement.step())
+        let blob = statement.row[0] as Blob
+        XCTAssertEqual("alice@example.com", String(bytes: blob.bytes, encoding: .utf8)!)
+
+        // verify that the transaction is not closed, which prevents wal_checkpoints (both explicit and auto)
+        do {
+            try db.run("pragma wal_checkpoint(truncate)")
+            XCTFail("Database should be locked")
+        } catch {
+            // pass
+        }
+
+        // reset the prepared statement, allowing the implicit transaction to close
+        statement.reset()
+
+        // truncate succeeds
+        try db.run("pragma wal_checkpoint(truncate)")
+    }
+
 }


### PR DESCRIPTION
For context, the sqlite docs: https://www.sqlite.org/lang_transaction.html#implicit_versus_explicit_transactions

> An implicit transaction (a transaction that is started automatically, not a transaction started by BEGIN) is committed automatically when the last active statement finishes. A statement finishes when its last cursor closes, which is guaranteed to happen when the prepared statement is [reset](https://www.sqlite.org/c3ref/reset.html) or [finalized](https://www.sqlite.org/c3ref/finalize.html). Some statements might "finish" for the purpose of transaction control prior to being reset or finalized, but there is no guarantee of this. The only way to ensure that a statement has "finished" is to invoke [sqlite3_reset()](https://www.sqlite.org/c3ref/reset.html) or [sqlite3_finalize()](https://www.sqlite.org/c3ref/finalize.html) on that statement.

For clients that keep and reuse prepared statements, that statement prevents transactions from fully closing (even after a `COMMIT`). This, in turn, prevents a wal checkpoint (both explicitly requested checkpoint and auto checkpoints) from succeeding. Since reset is only currently called when starting a new query or in `deinit`, this means for any long-lived prepared statement will prevent a wal checkpoint, causing the wal file to grow unbounded.

Instead, allowing clients to explicitly reset their prepared statements allows them to control when the transaction closes, which allows wal checkpoints to succeed.