### PR TITLE
Redirect README 404 to archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ These projects enhance or use SQLite.swift:
  - [SQLiteMigrationManager.swift][] (inspired by
    [FMDBMigrationManager][])
  - [Delta: Math helper](https://apps.apple.com/app/delta-math-helper/id1436506800)
-   (see [Delta/Utils/Database.swift](https://github.com/GroupeMINASTE/Delta-iOS/blob/master/Delta/Utils/Database.swift) for production implementation example)
+   (see [Delta/Utils/Database.swift](https://web.archive.org/web/20210823165515/https://github.com/GroupeMINASTE/Delta-iOS/blob/master/Delta/Utils/Database.swift) for production implementation example)
 
 
 ## Alternatives


### PR DESCRIPTION
GroupeMINASTE's Delta project seems to have been removed at some point. I've added a link to an archived version, but an extant production example would probably be better (do you know of any?).