### PR TITLE
Add TableBuilder overloads for two and three element foreign key constraints with optional values

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -658,6 +658,11 @@ using the following functions.
     t.foreignKey(user_id, references: users, id, delete: .setNull)
     // FOREIGN KEY("user_id") REFERENCES "users"("id") ON DELETE SET NULL
     ```
+    
+    ```swift
+    t.foreignKey((user_id, user_type), references: users, (id, type), delete: .setNull)
+    // FOREIGN KEY("user_id", "user_type") REFERENCES "users"("id", "type") ON DELETE SET NULL
+    ```
 
 <!-- TODO
 ### Creating a Table from a Select Statement

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -718,6 +718,11 @@ extension QueryType {
     public func upsert(_ insertValues: Setter..., onConflictOf conflicting: Expressible) -> Insert {
         upsert(insertValues, onConflictOf: conflicting)
     }
+    
+    public func upsert(_ insertValues: Setter..., onConflictOf conflicting: (Expressible, Expressible)) -> Insert {
+        let composite = ", ".join([conflicting.0, conflicting.1])
+        return upsert(insertValues, onConflictOf: composite)
+    }
 
     public func upsert(_ insertValues: [Setter], onConflictOf conflicting: Expressible) -> Insert {
         let setValues = insertValues.filter { $0.column.asSQL() != conflicting.asSQL() }

--- a/Sources/SQLite/Typed/Schema.swift
+++ b/Sources/SQLite/Typed/Schema.swift
@@ -569,6 +569,16 @@ public final class TableBuilder {
 
         foreignKey(composite, references, update, delete)
     }
+    
+    public func foreignKey<T: Value, U: Value, V: Value, W: Value>(_ composite: (Expression<T>, Expression<U>, Expression<V>, Expression<W?>),
+                                                         references table: QueryType,
+                                                         _ other: (Expression<T>, Expression<U>, Expression<V>, Expression<W>),
+                                                         update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1, composite.2, composite.3])
+        let references = (table, ", ".join([other.0, other.1, other.2, other.3]))
+
+        foreignKey(composite, references, update, delete)
+    }
 
     fileprivate func foreignKey(_ column: Expressible, _ references: (QueryType, Expressible),
                                 _ update: Dependency?, _ delete: Dependency?) {

--- a/Sources/SQLite/Typed/Schema.swift
+++ b/Sources/SQLite/Typed/Schema.swift
@@ -463,7 +463,104 @@ public final class TableBuilder {
         foreignKey(composite, references, update, delete)
     }
 
+    public func foreignKey<T: Value, U: Value>(_ composite: (Expression<T?>, Expression<U?>),
+                                               references table: QueryType, _ other: (Expression<T>, Expression<U>),
+                                               update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1])
+        let references = (table, ", ".join([other.0, other.1]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
+    public func foreignKey<T: Value, U: Value>(_ composite: (Expression<T>, Expression<U?>),
+                                               references table: QueryType, _ other: (Expression<T>, Expression<U>),
+                                               update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1])
+        let references = (table, ", ".join([other.0, other.1]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
+    public func foreignKey<T: Value, U: Value>(_ composite: (Expression<T?>, Expression<U>),
+                                               references table: QueryType, _ other: (Expression<T>, Expression<U>),
+                                               update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1])
+        let references = (table, ", ".join([other.0, other.1]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
     public func foreignKey<T: Value, U: Value, V: Value>(_ composite: (Expression<T>, Expression<U>, Expression<V>),
+                                                         references table: QueryType,
+                                                         _ other: (Expression<T>, Expression<U>, Expression<V>),
+                                                         update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1, composite.2])
+        let references = (table, ", ".join([other.0, other.1, other.2]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
+    public func foreignKey<T: Value, U: Value, V: Value>(_ composite: (Expression<T?>, Expression<U>, Expression<V>),
+                                                         references table: QueryType,
+                                                         _ other: (Expression<T>, Expression<U>, Expression<V>),
+                                                         update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1, composite.2])
+        let references = (table, ", ".join([other.0, other.1, other.2]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
+    public func foreignKey<T: Value, U: Value, V: Value>(_ composite: (Expression<T>, Expression<U?>, Expression<V>),
+                                                         references table: QueryType,
+                                                         _ other: (Expression<T>, Expression<U>, Expression<V>),
+                                                         update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1, composite.2])
+        let references = (table, ", ".join([other.0, other.1, other.2]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
+    public func foreignKey<T: Value, U: Value, V: Value>(_ composite: (Expression<T>, Expression<U>, Expression<V?>),
+                                                         references table: QueryType,
+                                                         _ other: (Expression<T>, Expression<U>, Expression<V>),
+                                                         update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1, composite.2])
+        let references = (table, ", ".join([other.0, other.1, other.2]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
+    public func foreignKey<T: Value, U: Value, V: Value>(_ composite: (Expression<T?>, Expression<U?>, Expression<V>),
+                                                         references table: QueryType,
+                                                         _ other: (Expression<T>, Expression<U>, Expression<V>),
+                                                         update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1, composite.2])
+        let references = (table, ", ".join([other.0, other.1, other.2]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
+    public func foreignKey<T: Value, U: Value, V: Value>(_ composite: (Expression<T>, Expression<U?>, Expression<V?>),
+                                                         references table: QueryType,
+                                                         _ other: (Expression<T>, Expression<U>, Expression<V>),
+                                                         update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1, composite.2])
+        let references = (table, ", ".join([other.0, other.1, other.2]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
+    public func foreignKey<T: Value, U: Value, V: Value>(_ composite: (Expression<T?>, Expression<U>, Expression<V?>),
+                                                         references table: QueryType,
+                                                         _ other: (Expression<T>, Expression<U>, Expression<V>),
+                                                         update: Dependency? = nil, delete: Dependency? = nil) {
+        let composite = ", ".join([composite.0, composite.1, composite.2])
+        let references = (table, ", ".join([other.0, other.1, other.2]))
+
+        foreignKey(composite, references, update, delete)
+    }
+    
+    public func foreignKey<T: Value, U: Value, V: Value>(_ composite: (Expression<T?>, Expression<U?>, Expression<V?>),
                                                          references table: QueryType,
                                                          _ other: (Expression<T>, Expression<U>, Expression<V>),
                                                          update: Dependency? = nil, delete: Dependency? = nil) {


### PR DESCRIPTION
The TableBuilder supports foreign key constraints with optional values for single column foreign keys. It also supports overloads for 2 and 3 column keys with no optional values. We ended up needing a bunch of different combinations of 2 and 3 column foreign keys with optional values in various places for a project.

This PR includes those extra overloads as well as a documentation example for how to use the multi-column foreign key support already in TableBuilder (which we ended up having to reference the code to figure out how to use).