### PR TITLE
Fix incorrect behavior when preparing SELECT * preceded by a WITH

### DIFF
--- a/Tests/SQLiteTests/Typed/QueryIntegrationTests.swift
+++ b/Tests/SQLiteTests/Typed/QueryIntegrationTests.swift
@@ -302,7 +302,7 @@ class QueryIntegrationTests: SQLiteTestCase {
 
         // There should be at least one row in the result.
         let row = try XCTUnwrap(rows.makeIterator().next())
-        
+
         // Verify the column names
         XCTAssertEqual(row.columnNames.count, 3)
         XCTAssertNotNil(row[id])

--- a/Tests/SQLiteTests/Typed/QueryIntegrationTests.swift
+++ b/Tests/SQLiteTests/Typed/QueryIntegrationTests.swift
@@ -276,6 +276,39 @@ class QueryIntegrationTests: SQLiteTestCase {
 
         XCTAssertEqual(21, sum)
     }
+
+    /// Verify that `*` is properly expanded in a SELECT statement following a WITH clause.
+    func test_with_glob_expansion() throws {
+        let names = Table("names")
+        let name = Expression<String>("name")
+        try db.run(names.create { builder in
+            builder.column(email)
+            builder.column(name)
+        })
+
+        try db.run(users.insert(email <- "alice@example.com"))
+        try db.run(names.insert(email <- "alice@example.com", name <- "Alice"))
+
+        // WITH intermediate AS ( SELECT ... ) SELECT * FROM intermediate
+        let intermediate = Table("intermediate")
+        let rows = try db.prepare(
+            intermediate
+                .with(intermediate,
+                      as: users
+                        .select([id, users[email], name])
+                        .join(names, on: names[email] == users[email])
+                        .where(users[email] == "alice@example.com")
+                     ))
+
+        // There should be at least one row in the result.
+        let row = try XCTUnwrap(rows.makeIterator().next())
+        
+        // Verify the column names
+        XCTAssertEqual(row.columnNames.count, 3)
+        XCTAssertNotNil(row[id])
+        XCTAssertNotNil(row[name])
+        XCTAssertNotNil(row[email])
+    }
 }
 
 extension Connection {


### PR DESCRIPTION
In  #1139 I introduced support for the `WITH` clause. My implementation contains a bug: preparing a query containing a `SELECT *` preceded by a `WITH` causes an error to be thrown.

Consider the following statement:

```sql
WITH temp AS ( SELECT id, email from users) SELECT * from temp
```

An error is thrown when preparing this statement because the glob expansion procedure tries to determine the column names for the result by looking up the column names for the query `SELECT * from temp`. This does not work because `temp` is a temporary view defined in the `WITH` clause.

To fix this, I modified the glob expansion procedure to include the `WITH` clause in the query used to look up the result column names.
