### PR TITLE
Make ithe IndexDefinition properties public

### DIFF
--- a/Sources/SQLite/Schema/SchemaDefinitions.swift
+++ b/Sources/SQLite/Schema/SchemaDefinitions.swift
@@ -266,12 +266,12 @@ public struct IndexDefinition: Equatable {
                   orders: indexSQL.flatMap(orders))
     }
 
-    let table: String
-    let name: String
-    let unique: Bool
-    let columns: [String]
-    let `where`: String?
-    let orders: [String: Order]?
+    public let table: String
+    public let name: String
+    public let unique: Bool
+    public let columns: [String]
+    public let `where`: String?
+    public let orders: [String: Order]?
 
     enum IndexError: LocalizedError {
         case tooLong(String, String)


### PR DESCRIPTION
The [documentation](https://github.com/stephencelis/SQLite.swift/blob/master/Documentation/Index.md#querying-the-schema) suggests that the index schema information can be queried. That requires the `IndexDefinition` properties to be public.

At the moment, the following code does not work, when used in an project that depends on SQLite.swift:

```swift
let indexes = try schema.indexDefinitions("users")

for index in indexes {
    print("\(index.name) columns:\(index.columns))") // <- index.name and index.columns is not visible
}

```

`ObjectDefinition` and `ColumnDefinition` properties are already public, so it seems not to far fetched to change the `IndexDefinition` properties as well?
