### PR TITLE
SchemaReader: return the correct column definition for a composite primary key

### DIFF
--- a/Sources/SQLite/Schema/SchemaReader.swift
+++ b/Sources/SQLite/Schema/SchemaReader.swift
@@ -25,7 +25,7 @@ public class SchemaReader {
             .map { (row: Row) -> ColumnDefinition in
                 ColumnDefinition(
                     name: row[TableInfoTable.nameColumn],
-                    primaryKey: row[TableInfoTable.primaryKeyColumn] == 1 ?
+                    primaryKey: (row[TableInfoTable.primaryKeyColumn] ?? 0) > 0 ?
                         try parsePrimaryKey(column: row[TableInfoTable.nameColumn]) : nil,
                     type: ColumnDefinition.Affinity(row[TableInfoTable.typeColumn]),
                     nullable: row[TableInfoTable.notNullColumn] == 0,

--- a/Tests/SQLiteTests/Schema/SchemaReaderTests.swift
+++ b/Tests/SQLiteTests/Schema/SchemaReaderTests.swift
@@ -90,6 +90,43 @@ class SchemaReaderTests: SQLiteTestCase {
         )
     }
 
+    func test_columnDefinitions_composite_primary_keys() throws {
+        try db.run("""
+        CREATE TABLE t (
+          col1 INTEGER,
+          col2 INTEGER,
+          col3 INTEGER,
+          PRIMARY KEY (col1, col2)
+        );
+        """)
+
+        XCTAssertEqual(
+            try schemaReader.columnDefinitions(table: "t"), [
+            ColumnDefinition(
+                    name: "col1",
+                    primaryKey: .init(autoIncrement: false),
+                    type: .INTEGER,
+                    nullable: true,
+                    defaultValue: .NULL,
+                    references: nil),
+            ColumnDefinition(
+                    name: "col2",
+                    primaryKey: .init(autoIncrement: false),
+                    type: .INTEGER,
+                    nullable: true,
+                    defaultValue: .NULL,
+                    references: nil),
+            ColumnDefinition(
+                    name: "col3",
+                    primaryKey: nil,
+                    type: .INTEGER,
+                    nullable: true,
+                    defaultValue: .NULL,
+                    references: nil)
+            ]
+        )
+    }
+
     func test_indexDefinitions_no_index() throws {
         let indexes = try schemaReader.indexDefinitions(table: "users")
         XCTAssertTrue(indexes.isEmpty)


### PR DESCRIPTION
The `PRAGMA` `table_info` that is used to return the column definitions, returns one row for each defined column. The `pk` column contains:

> ... either zero for columns that are not part of the primary key, or the 1-based index of the column within the primary key).

See https://www.sqlite.org/pragma.html#pragma_table_info

Checking whether the `pk` column equals 1 only detects a single primary key and ignores other columns that are part of a composite primary key.

Thanks for taking the time to submit a pull request.

Before submitting, please do the following:

- Run `make lint` to check if there are any format errors (install [swiftlint](https://github.com/realm/SwiftLint#installation) first)
- Run `swift test` to see if the tests pass.
- Write new tests for new functionality.
- Update documentation comments where applicable.

