### PR TITLE
Fix #1247 support nil case when decoding optionals

### DIFF
--- a/Sources/SQLite/Typed/Coding.swift
+++ b/Sources/SQLite/Typed/Coding.swift
@@ -504,9 +504,8 @@ private class SQLiteDecoder: Decoder {
             case is UUID.Type:
                 return try? row.get(Expression<UUID>(key.stringValue)) as? T
             default:
-                guard let JSONString = try? row.get(Expression<String?>(key.stringValue)) else {
-                    throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: codingPath,
-                                                                                 debugDescription: "an unsupported type was found"))
+                guard let JSONString = try row.get(Expression<String?>(key.stringValue)) else {
+                    return nil
                 }
                 guard let data = JSONString.data(using: .utf8) else {
                     throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath,


### PR DESCRIPTION
#1247 describes a bug where decoding a nil value in an optional throws an error when nil is a valid response.

This same bug occurs with arrays or structs encoded to either optional string or data types.


## Testing
I added a unit test "test_insert_custom_encodable_type" which demonstrates the issue. The current master branch fails when decoding a nil value. 