### PR TITLE
Update CoreFunctions.swift fix typo

### DIFF
--- a/Sources/SQLite/Typed/CoreFunctions.swift
+++ b/Sources/SQLite/Typed/CoreFunctions.swift
@@ -224,7 +224,7 @@ extension ExpressionType where UnderlyingType == String {
     ///
     ///     let name = Expression<String>("name")
     ///     name.uppercaseString
-    ///     // lower("name")
+    ///     // upper("name")
     ///
     /// - Returns: A copy of the expression wrapped with the `upper` function.
     public var uppercaseString: Expression<UnderlyingType> {


### PR DESCRIPTION
just fix a typo which change 'lower' to 'upper'