### PR TITLE
fix: visionos to cocoapods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.15.2 (16-04-2024), [diff][diff-0.15.2]
+========================================
+* fix: visionos to cocoapods ([#1260][])
+
 0.15.1 (14-04-2024), [diff][diff-0.15.1]
 ========================================
 
@@ -164,6 +168,7 @@ For breaking changes, see [Upgrading.md](Documentation/Upgrading.md).
 [diff-0.14.1]: https://github.com/stephencelis/SQLite.swift/compare/0.14.0...0.14.1
 [diff-0.15.0]: https://github.com/stephencelis/SQLite.swift/compare/0.14.0...0.15.0
 [diff-0.15.1]: https://github.com/stephencelis/SQLite.swift/compare/0.15.0...0.15.1
+[diff-0.15.2]: https://github.com/stephencelis/SQLite.swift/compare/0.15.1...0.15.2
 
 [#30]: https://github.com/stephencelis/SQLite.swift/issues/30
 [#142]: https://github.com/stephencelis/SQLite.swift/issues/142
@@ -248,3 +253,4 @@ For breaking changes, see [Upgrading.md](Documentation/Upgrading.md).
 [#1248]: https://github.com/stephencelis/SQLite.swift/pull/1248
 [#1255]: https://github.com/stephencelis/SQLite.swift/pull/1255
 [#1237]: https://github.com/stephencelis/SQLite.swift/pull/1237
+[#1260]: https://github.com/stephencelis/SQLite.swift/pull/1260

--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -108,7 +108,7 @@ process of downloading, compiling, and linking dependencies.
 
   ```swift
   dependencies: [
-    .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.1")
+    .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.2")
   ]
   ```
 
@@ -129,7 +129,7 @@ install SQLite.swift with Carthage:
  2. Update your Cartfile to include the following:
 
     ```ruby
-    github "stephencelis/SQLite.swift" ~> 0.15.1
+    github "stephencelis/SQLite.swift" ~> 0.15.2
     ```
 
  3. Run `carthage update` and [add the appropriate framework][Carthage Usage].
@@ -159,7 +159,7 @@ install SQLite.swift with Carthage:
     use_frameworks!
 
     target 'YourAppTargetName' do
-        pod 'SQLite.swift', '~> 0.15.1'
+        pod 'SQLite.swift', '~> 0.15.2'
     end
     ```
 
@@ -173,7 +173,7 @@ with the OS you can require the `standalone` subspec:
 
 ```ruby
 target 'YourAppTargetName' do
-  pod 'SQLite.swift/standalone', '~> 0.15.1'
+  pod 'SQLite.swift/standalone', '~> 0.15.2'
 end
 ```
 
@@ -183,7 +183,7 @@ dependency to sqlite3 or one of its subspecs:
 
 ```ruby
 target 'YourAppTargetName' do
-  pod 'SQLite.swift/standalone', '~> 0.15.1'
+  pod 'SQLite.swift/standalone', '~> 0.15.2'
   pod 'sqlite3/fts5', '= 3.15.0'  # SQLite 3.15.0 with FTS5 enabled
 end
 ```
@@ -199,7 +199,7 @@ If you want to use [SQLCipher][] with SQLite.swift you can require the
 target 'YourAppTargetName' do
   # Make sure you only require the subspec, otherwise you app might link against
   # the system SQLite, which means the SQLCipher-specific methods won't work.
-  pod 'SQLite.swift/SQLCipher', '~> 0.15.1'
+  pod 'SQLite.swift/SQLCipher', '~> 0.15.2'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Swift code.
 
   ```swift
   dependencies: [
-      .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.1")
+      .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.2")
   ]
   ```
 
@@ -152,7 +152,7 @@ install SQLite.swift with Carthage:
  2. Update your Cartfile to include the following:
 
     ```ruby
-    github "stephencelis/SQLite.swift" ~> 0.15.1
+    github "stephencelis/SQLite.swift" ~> 0.15.2
     ```
 
  3. Run `carthage update` and

--- a/SQLite.swift.podspec
+++ b/SQLite.swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SQLite.swift"
-  s.version          = "0.15.1"
+  s.version          = "0.15.2"
   s.summary          = "A type-safe, Swift-language layer over SQLite3."
 
   s.description      = <<-DESC
@@ -22,11 +22,13 @@ Pod::Spec.new do |s|
   tvos_deployment_target = '12.0'
   osx_deployment_target = '10.13'
   watchos_deployment_target = '4.0'
+  visionos_deployment_target = '1.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.tvos.deployment_target = tvos_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
+  s.visionos.deployment_target = visionos_deployment_target
 
   s.subspec 'standard' do |ss|
     ss.source_files = 'Sources/SQLite/**/*.{c,h,m,swift}'
@@ -37,6 +39,7 @@ Pod::Spec.new do |s|
     ss.tvos.deployment_target = tvos_deployment_target
     ss.osx.deployment_target = osx_deployment_target
     ss.watchos.deployment_target = watchos_deployment_target
+    ss.visionos.deployment_target = visionos_deployment_target
 
     ss.test_spec 'tests' do |test_spec|
       test_spec.resources = 'Tests/SQLiteTests/Resources/*'
@@ -61,6 +64,7 @@ Pod::Spec.new do |s|
     ss.tvos.deployment_target = tvos_deployment_target
     ss.osx.deployment_target = osx_deployment_target
     ss.watchos.deployment_target = watchos_deployment_target
+    ss.visionos.deployment_target = visionos_deployment_target
 
     ss.test_spec 'tests' do |test_spec|
       test_spec.resources = 'Tests/SQLiteTests/Resources/*'
@@ -83,6 +87,7 @@ Pod::Spec.new do |s|
     ss.tvos.deployment_target = tvos_deployment_target
     ss.osx.deployment_target = osx_deployment_target
     ss.watchos.deployment_target = watchos_deployment_target
+    ss.visionos.deployment_target = visionos_deployment_target
 
     ss.test_spec 'tests' do |test_spec|
       test_spec.resources = 'Tests/SQLiteTests/Resources/*'

--- a/SQLite.swift.podspec
+++ b/SQLite.swift.podspec
@@ -87,7 +87,7 @@ Pod::Spec.new do |s|
     ss.tvos.deployment_target = tvos_deployment_target
     ss.osx.deployment_target = osx_deployment_target
     ss.watchos.deployment_target = watchos_deployment_target
-    ss.visionos.deployment_target = visionos_deployment_target
+    #ss.visionos.deployment_target = visionos_deployment_target # Not supported by SQLCipher for now
 
     ss.test_spec 'tests' do |test_spec|
       test_spec.resources = 'Tests/SQLiteTests/Resources/*'

--- a/Tests/SPM/Package.swift
+++ b/Tests/SPM/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         // for testing from same repository
         .package(path: "../..")
         // normally this would be:
-        // .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.1")
+        // .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.2")
     ],
     targets: [
         .executableTarget(name: "test", dependencies: [.product(name: "SQLite", package: "SQLite.swift")])


### PR DESCRIPTION
Fixes related to #1237 (missing visionOS on cocoapods)

EDIT: Currently SQLCipher is missing visionOS in its podspec too