### PR TITLE
Fix force try in the `FailableIterator.next()` and `Connection.prepare()` methods

### DIFF
--- a/Sources/SQLite/Core/Statement.swift
+++ b/Sources/SQLite/Core/Statement.swift
@@ -214,8 +214,8 @@ public protocol FailableIterator: IteratorProtocol {
 
 extension FailableIterator {
     public func next() -> Element? {
-        // swiftlint:disable:next force_try
-        try! failableNext()
+        // Do not force try 
+        try? failableNext()
     }
 }
 

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1009,10 +1009,9 @@ extension Connection {
         let statement = try prepare(expression.template, expression.bindings)
 
         let columnNames = try columnNamesForQuery(query)
+        let rows = try statement.failableNext().map { Row(columnNames, $0) }
 
-        return AnySequence {
-            AnyIterator { statement.next().map { Row(columnNames, $0) } }
-        }
+        return AnySequence { AnyIterator { rows } }
     }
 
     public func prepareRowIterator(_ query: QueryType) throws -> RowIterator {


### PR DESCRIPTION
The force try is crashing and ideally, the prepare() query should throw the error rather than crashing the app. Thanks! 

Thanks for taking the time to submit a pull request.

Before submitting, please do the following:

- Run `make lint` to check if there are any format errors (install [swiftlint](https://github.com/realm/SwiftLint#installation) first)
- Run `swift test` to see if the tests pass.
- Write new tests for new functionality.
- Update documentation comments where applicable.

