### PR TITLE
Update oldest supported platform versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,10 +4,10 @@ import PackageDescription
 let package = Package(
     name: "SQLite.swift",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v12),
         .macOS(.v10_13),
         .watchOS(.v4),
-        .tvOS(.v11),
+        .tvOS(.v12),
         .visionOS(.v1)
     ],
     products: [


### PR DESCRIPTION
Hi, I'm submitting a simple pull request:

The versions for the `iOS` and `tvOS` platforms in _Package.swift_ were deprecated so I updated them to `.v12`.

I ran `make lint` and found 0 violations, but I did get a number of errors when I ran `swift test`, most of which appeared to be because a `value:` label is needed for method parameters, also ones that said a generic parameter 'V' cound not be inferred.

Please let me know if there's anything else you'd like me to do before accepting this.

Thanks,
Cary