### PR TITLE
Added alias to column names

### DIFF
--- a/Sources/SQLite/Typed/Expression.swift
+++ b/Sources/SQLite/Typed/Expression.swift
@@ -105,6 +105,10 @@ extension ExpressionType {
         " ".join([self, Expression<Void>(literal: "DESC")])
     }
 
+    public func `as`(_ name: String) -> Expressible {
+        " ".join([self, Expression<Void>(literal: "AS \(name)")])
+    }
+
 }
 
 extension ExpressionType where UnderlyingType: Value {


### PR DESCRIPTION
Adding alias for column name to disambiguate complex queries.

Usage:

```swift
let idColumn = Expression<Int64>("id")
let idColumnAlias = idColumn.as("user_id")
```

