### PR TITLE
Create index support array as parameters to solve #1322

### DIFF
--- a/Sources/SQLite/Typed/Schema.swift
+++ b/Sources/SQLite/Typed/Schema.swift
@@ -135,8 +135,8 @@ extension Table {
     }
 
     // MARK: - CREATE INDEX
-
-    public func createIndex(_ columns: Expressible..., unique: Bool = false, ifNotExists: Bool = false) -> String {
+    
+    public func createIndex(_ columns: [Expressible], unique: Bool = false, ifNotExists: Bool = false) -> String {
         let clauses: [Expressible?] = [
             create("INDEX", indexName(columns), unique ? .unique : nil, ifNotExists),
             Expression<Void>(literal: "ON"),
@@ -146,11 +146,19 @@ extension Table {
 
         return " ".join(clauses.compactMap { $0 }).asSQL()
     }
+    
+    public func createIndex(_ columns: Expressible..., unique: Bool = false, ifNotExists: Bool = false) -> String {
+        return createIndex(Array(columns), unique: unique, ifNotExists: ifNotExists)
+    }
 
     // MARK: - DROP INDEX
-
-    public func dropIndex(_ columns: Expressible..., ifExists: Bool = false) -> String {
+    
+    public func dropIndex(_ columns: [Expressible], ifExists: Bool = false) -> String {
         drop("INDEX", indexName(columns), ifExists)
+    }
+    
+    public func dropIndex(_ columns: Expressible..., ifExists: Bool = false) -> String {
+        dropIndex(Array(columns), ifExists: ifExists)
     }
 
     fileprivate func indexName(_ columns: [Expressible]) -> Expressible {


### PR DESCRIPTION
Thanks for taking the time to submit a pull request.

Before submitting, please do the following:

- Run `make lint` to check if there are any format errors (install [swiftlint](https://github.com/realm/SwiftLint#installation) first)
- Run `swift test` to see if the tests pass.
- Write new tests for new functionality.
- Update documentation comments where applicable.

overload `public func createIndex(_ columns: [Expressible], unique: Bool = false, ifNotExists: Bool = false) -> String` and `public func dropIndex(_ columns: [Expressible], ifExists: Bool = false) -> String` to solve [#1322](https://github.com/stephencelis/SQLite.swift/issues/1322)
