### PR TITLE
Added support for casting when Codable.

### DIFF
--- a/Sources/SQLite/Core/Statement.swift
+++ b/Sources/SQLite/Core/Statement.swift
@@ -166,7 +166,7 @@ public final class Statement {
 
         reset(clearBindings: false)
         _ = try step()
-        return row[0]
+		return try row.getValue(0)
     }
 
     /// - Parameter bindings: A list of parameters to bind to the statement.
@@ -229,9 +229,9 @@ extension Array {
 }
 
 extension Statement: FailableIterator {
-    public typealias Element = [Binding?]
-    public func failableNext() throws -> [Binding?]? {
-        try step() ? Array(row) : nil
+    public typealias Element = Cursor
+    public func failableNext() throws -> Cursor? {
+        try step() ? row : nil
     }
 }
 
@@ -258,30 +258,68 @@ extension Statement: CustomStringConvertible {
 
 }
 
-public struct Cursor {
+public protocol CursorProtocol {
+	func getValue(_ idx: Int) throws -> Binding?
+	func getValue(_ idx: Int) throws -> Double
+	func getValue(_ idx: Int) throws -> Int64
+	func getValue(_ idx: Int) throws -> String
+	func getValue(_ idx: Int) throws -> Blob
+}
 
-    fileprivate let handle: OpaquePointer
+extension CursorProtocol {
+	public func getValue<T: Binding>(_ idx: Int) -> T? {
+		switch T.self {
+		case is Double.Type:
+			return try? getValue(idx) as Double as? T
+		case is Int64.Type:
+			return try? getValue(idx) as Int64 as? T
+		case is String.Type:
+			return try? getValue(idx) as String as? T
+		case is Blob.Type:
+			return try? getValue(idx) as Blob as? T
+		default:
+			return nil
+		}
+	}
+
+	public func getValue(_ idx: Int) throws -> Bool {
+		try Bool.fromDatatypeValue(getValue(idx))
+	}
+
+	public func getValue(_ idx: Int) throws -> Int {
+		try Int.fromDatatypeValue(getValue(idx))
+	}
+}
+
+public struct Cursor: CursorProtocol {
+    fileprivate let statement: Statement
+	fileprivate var handle: OpaquePointer {
+		statement.handle!
+	}
 
     fileprivate let columnCount: Int
 
     fileprivate init(_ statement: Statement) {
-        handle = statement.handle!
+		self.statement = statement
         columnCount = statement.columnCount
     }
 
-    public subscript(idx: Int) -> Double {
+    public func getValue(_ idx: Int) throws -> Double {
         sqlite3_column_double(handle, Int32(idx))
     }
 
-    public subscript(idx: Int) -> Int64 {
+    public func getValue(_ idx: Int) throws -> Int64 {
         sqlite3_column_int64(handle, Int32(idx))
     }
 
-    public subscript(idx: Int) -> String {
-        String(cString: UnsafePointer(sqlite3_column_text(handle, Int32(idx))))
+    public func getValue(_ idx: Int) throws -> String {
+		guard let text = sqlite3_column_text(handle, Int32(idx)) else {
+			throw QueryError.unexpectedNullValue(name: "column at index \(idx)")
+		}
+        return String(cString: UnsafePointer(text))
     }
 
-    public subscript(idx: Int) -> Blob {
+    public func getValue(_ idx: Int) throws -> Blob {
         if let pointer = sqlite3_column_blob(handle, Int32(idx)) {
             let length = Int(sqlite3_column_bytes(handle, Int32(idx)))
             return Blob(bytes: pointer, length: length)
@@ -292,48 +330,20 @@ public struct Cursor {
         }
     }
 
-    // MARK: -
-
-    public subscript(idx: Int) -> Bool {
-        Bool.fromDatatypeValue(self[idx])
-    }
-
-    public subscript(idx: Int) -> Int {
-        Int.fromDatatypeValue(self[idx])
-    }
-
-}
-
-/// Cursors provide direct access to a statement’s current row.
-extension Cursor: Sequence {
-
-    public subscript(idx: Int) -> Binding? {
+    public func getValue(_ idx: Int) throws -> Binding? {
         switch sqlite3_column_type(handle, Int32(idx)) {
         case SQLITE_BLOB:
-            return self[idx] as Blob
+            return try getValue(idx) as Blob
         case SQLITE_FLOAT:
-            return self[idx] as Double
+            return try getValue(idx) as Double
         case SQLITE_INTEGER:
-            return self[idx] as Int64
+            return try getValue(idx) as Int64
         case SQLITE_NULL:
             return nil
         case SQLITE_TEXT:
-            return self[idx] as String
+            return try getValue(idx) as String
         case let type:
             fatalError("unsupported column type: \(type)")
         }
     }
-
-    public func makeIterator() -> AnyIterator<Binding?> {
-        var idx = 0
-        return AnyIterator {
-            if idx >= columnCount {
-                return .none
-            } else {
-                idx += 1
-                return self[idx - 1]
-            }
-        }
-    }
-
 }

--- a/Sources/SQLite/Schema/Connection+Schema.swift
+++ b/Sources/SQLite/Schema/Connection+Schema.swift
@@ -14,10 +14,10 @@ public extension Connection {
     // https://sqlite.org/pragma.html#pragma_foreign_key_check
     func foreignKeyCheck(table: String? = nil) throws -> [ForeignKeyError] {
         try run("PRAGMA foreign_key_check" + (table.map { "(\($0.quote()))" } ?? ""))
-            .compactMap { (row: [Binding?]) -> ForeignKeyError? in
-                guard let table = row[0] as? String,
-                      let rowId = row[1] as? Int64,
-                      let target = row[2] as? String else { return nil }
+            .compactMap { (row: Cursor) -> ForeignKeyError? in
+				guard let table = row.getValue(0) as String?,
+                      let rowId = row.getValue(1) as Int64?,
+                      let target = row.getValue(2) as String? else { return nil }
 
                 return ForeignKeyError(from: table, rowId: rowId, to: target)
             }
@@ -29,7 +29,7 @@ public extension Connection {
         precondition(table == nil || supports(.partialIntegrityCheck), "partial integrity check not supported")
 
         return try run("PRAGMA integrity_check" + (table.map { "(\($0.quote()))" } ?? ""))
-            .compactMap { $0[0] as? String }
+            .compactMap { $0.getValue(0) as String? }
             .filter { $0 != "ok" }
     }
 }

--- a/Sources/SQLite/Typed/Query.swift
+++ b/Sources/SQLite/Typed/Query.swift
@@ -1010,11 +1010,7 @@ extension Connection {
 
         let columnNames = try columnNamesForQuery(query)
 
-		return AnyIterator {
-			statement.next().map {
-				Row(columnNames, $0)
-			}
-		}.lazy
+		return AnyIterator { statement.next().map { Row(columnNames, $0) } }.lazy
     }
 
     public func prepareRowIterator(_ query: QueryType) throws -> RowIterator {
@@ -1203,9 +1199,7 @@ public struct Row {
 
     public func get<V: Value>(_ column: Expression<V?>) throws -> V? {
         func valueAtIndex(_ idx: Int) throws -> V? {
-            guard
-				let value = try (values.getValue(idx) as V.Datatype?) ?? (values.getValue(idx) as Binding? as? V.Datatype)
-			else { return nil }
+            guard let value = try (values.getValue(idx) as V.Datatype?) ?? (values.getValue(idx) as Binding? as? V.Datatype) else { return nil }
             return try V.fromDatatypeValue(value) as? V
         }
 
@@ -1241,7 +1235,7 @@ public struct Row {
 
     public subscript<T: Value>(column: Expression<T?>) -> T? {
         // swiftlint:disable:next force_try
-        try? get(column)
+        try! get(column)
     }
 }
 

--- a/Tests/SQLiteTests/Core/Connection+AttachTests.swift
+++ b/Tests/SQLiteTests/Core/Connection+AttachTests.swift
@@ -29,7 +29,7 @@ class ConnectionAttachTests: SQLiteTestCase {
 
         // query data
         let rows = try db.prepare(table.select(name)).map { $0[name] }
-        XCTAssertEqual(["test"], rows)
+        XCTAssertEqual(["test"], Array(rows))
 
         try db.detach(schemaName)
     }
@@ -44,7 +44,7 @@ class ConnectionAttachTests: SQLiteTestCase {
         let email = SQLite.Expression<String>("email")
 
         let rows = try db.prepare(table.select(email)).map { $0[email] }
-        XCTAssertEqual(["foo@bar.com"], rows)
+        XCTAssertEqual(["foo@bar.com"], Array(rows))
 
         try db.detach(schemaName)
     }

--- a/Tests/SQLiteTests/Core/ConnectionTests.swift
+++ b/Tests/SQLiteTests/Core/ConnectionTests.swift
@@ -175,7 +175,7 @@ class ConnectionTests: SQLiteTestCase {
         try backup.step()
 
         let users = try target.prepare("SELECT email FROM users ORDER BY email")
-        XCTAssertEqual(users.map { $0[0] as? String }, ["alice@example.com", "betsy@example.com"])
+		XCTAssertEqual(users.map { $0.getValue(0) as String? }, ["alice@example.com", "betsy@example.com"])
     }
 
     func test_transaction_beginsAndCommitsTransactions() throws {

--- a/Tests/SQLiteTests/Core/StatementTests.swift
+++ b/Tests/SQLiteTests/Core/StatementTests.swift
@@ -21,7 +21,7 @@ class StatementTests: SQLiteTestCase {
         try insertUsers("alice")
         let statement = try db.prepare("SELECT email FROM users")
         XCTAssert(try statement.step())
-        let blob = statement.row[0] as Blob
+        let blob = try statement.row.getValue(0) as Blob
         XCTAssertEqual("alice@example.com", String(bytes: blob.bytes, encoding: .utf8)!)
     }
 

--- a/Tests/SQLiteTests/Extensions/FTSIntegrationTests.swift
+++ b/Tests/SQLiteTests/Extensions/FTSIntegrationTests.swift
@@ -50,14 +50,14 @@ class FTSIntegrationTests: SQLiteTestCase {
 
     func testMatch() throws {
         try createIndex()
-        let matches = Array(try db.prepare(index.match("Paul")))
+        let matches = try db.prepare(index.match("Paul"))
         XCTAssertEqual(matches.map { $0[email ]}, ["Paul@example.com"])
     }
 
     func testMatchPartial() throws {
         try insertUsers("Paula")
         try createIndex()
-        let matches = Array(try db.prepare(index.match("Pa*")))
+        let matches = try db.prepare(index.match("Pa*"))
         XCTAssertEqual(matches.map { $0[email ]}, ["Paul@example.com", "Paula@example.com"])
     }
 

--- a/Tests/SQLiteTests/Typed/CustomAggregationTests.swift
+++ b/Tests/SQLiteTests/Typed/CustomAggregationTests.swift
@@ -46,7 +46,7 @@ class CustomAggregationTests: SQLiteTestCase {
         let result = try db.prepare("SELECT mySUM1(age) AS s FROM users")
         let i = result.columnNames.firstIndex(of: "s")!
         for row in result {
-            let value = row[i] as? Int64
+            let value = row.getValue(i) as Int64?
             XCTAssertEqual(83, value)
         }
     }
@@ -70,7 +70,7 @@ class CustomAggregationTests: SQLiteTestCase {
         }
         let result = try db.prepare("SELECT mySUM2(age) AS s FROM users GROUP BY admin ORDER BY s")
         let i = result.columnNames.firstIndex(of: "s")!
-        let values = result.compactMap { $0[i] as? Int64 }
+        let values = result.compactMap { $0.getValue(i) as Int64? }
         XCTAssertTrue(values.elementsEqual([28, 55]))
     }
 
@@ -83,7 +83,7 @@ class CustomAggregationTests: SQLiteTestCase {
         let result = try db.prepare("SELECT myReduceSUM1(age) AS s FROM users")
         let i = result.columnNames.firstIndex(of: "s")!
         for row in result {
-            let value = row[i] as? Int64
+            let value = row.getValue(i) as Int64?
             XCTAssertEqual(2083, value)
         }
     }
@@ -96,7 +96,7 @@ class CustomAggregationTests: SQLiteTestCase {
         db.createAggregation("myReduceSUM2", initialValue: Int64(3000), reduce: reduce, result: { $0 })
         let result = try db.prepare("SELECT myReduceSUM2(age) AS s FROM users GROUP BY admin ORDER BY s")
         let i = result.columnNames.firstIndex(of: "s")!
-        let values = result.compactMap { $0[i] as? Int64 }
+        let values = result.compactMap { $0.getValue(i) as Int64? }
         XCTAssertTrue(values.elementsEqual([3028, 3055]))
     }
 
@@ -111,7 +111,7 @@ class CustomAggregationTests: SQLiteTestCase {
 
         let i = result.columnNames.firstIndex(of: "s")!
         for row in result {
-            let value = row[i] as? String
+            let value = row.getValue(i) as String?
             XCTAssertEqual("\(initial)Alice@example.comBob@example.comEve@example.com", value)
         }
     }
@@ -134,7 +134,7 @@ class CustomAggregationTests: SQLiteTestCase {
             let result = try! db.prepare("SELECT myReduceSUMX(age) AS s FROM users")
             let i = result.columnNames.firstIndex(of: "s")!
             for row in result {
-                let value = row[i] as? Int64
+                let value = row.getValue(i) as Int64?
                 XCTAssertEqual(1083, value)
             }
         }()

--- a/Tests/SQLiteTests/Typed/QueryIntegrationTests.swift
+++ b/Tests/SQLiteTests/Typed/QueryIntegrationTests.swift
@@ -49,7 +49,7 @@ class QueryIntegrationTests: SQLiteTestCase {
         let names = ["a", "b", "c"]
         try insertUsers(names)
 
-        let emails = try db.prepare("select email from users", []).map { $0[0] as! String  }
+		let emails = try db.prepare("select email from users", []).compactMap { try? $0.getValue(0) as String  }
 
         XCTAssertEqual(names.map({ "\($0)@example.com" }), emails.sorted())
     }
@@ -213,8 +213,8 @@ class QueryIntegrationTests: SQLiteTestCase {
         let query1 = users.filter(email == "alice@example.com")
         let query2 = users.filter(email == "sally@example.com")
 
-        let actualIDs = try db.prepare(query1.union(query2)).map { $0[id] }
-        XCTAssertEqual(expectedIDs, actualIDs)
+		let actualIDs = try db.prepare(query1.union(query2)).map { $0[self.id] }
+        XCTAssertEqual(expectedIDs, Array(actualIDs))
 
         let query3 = users.select(users[*], SQLite.Expression<Int>(literal: "1 AS weight")).filter(email == "sally@example.com")
         let query4 = users.select(users[*], SQLite.Expression<Int>(literal: "2 AS weight")).filter(email == "alice@example.com")
@@ -226,8 +226,8 @@ class QueryIntegrationTests: SQLiteTestCase {
         SELECT "users".*, 2 AS weight FROM "users" WHERE ("email" = 'alice@example.com') ORDER BY weight
         """)
 
-        let orderedIDs = try db.prepare(query3.union(query4).order(SQLite.Expression<Int>(literal: "weight"), email)).map { $0[id] }
-        XCTAssertEqual(Array(expectedIDs.reversed()), orderedIDs)
+		let orderedIDs = try db.prepare(query3.union(query4).order(SQLite.Expression<Int>(literal: "weight"), email)).map { $0[self.id] }
+        XCTAssertEqual(Array(expectedIDs.reversed()), Array(orderedIDs))
     }
 
     func test_no_such_column() throws {
@@ -376,7 +376,7 @@ class QueryIntegrationTests: SQLiteTestCase {
         let results = try db.prepare(users.select(id, cumeDist)).map {
             $0[cumeDist]
         }
-        XCTAssertEqual([0.25, 0.5, 0.75, 1], results)
+        XCTAssertEqual([0.25, 0.5, 0.75, 1], Array(results))
     }
 
     func test_select_window_row_number() throws {
@@ -444,6 +444,28 @@ class QueryIntegrationTests: SQLiteTestCase {
         row = try db.pluck(users.select(id, nthValue))!
         XCTAssertEqual(row[nthValue], "Billy@example.com")
     }
+
+	func test_codable_cast() throws {
+		let table = Table("test_codable_cast")
+		try db.run(
+			table.create {
+				$0.column(SQLite.Expression<String?>("int"))
+				$0.column(SQLite.Expression<String?>("string"))
+				$0.column(SQLite.Expression<String?>("bool"))
+				$0.column(SQLite.Expression<String?>("float"))
+				$0.column(SQLite.Expression<String?>("double"))
+				$0.column(SQLite.Expression<String?>("date"))
+				$0.column(SQLite.Expression<String?>("uuid"))
+				$0.column(SQLite.Expression<String?>("optional"))
+				$0.column(SQLite.Expression<String?>("sub"))
+			})
+		let value = TestCodable(int: 1, string: "2", bool: true, float: 3, double: 4,
+								date: Date(timeIntervalSince1970: 0), uuid: testUUIDValue, optional: nil, sub: nil)
+		try db.run(table.insert(value))
+
+		let fetchValue: TestCodable = try db.prepare(table).map { try $0.decode() }[0]
+		XCTAssertEqual(fetchValue, value)
+	}
 }
 
 extension Connection {

--- a/Tests/SQLiteTests/Typed/RowTests.swift
+++ b/Tests/SQLiteTests/Typed/RowTests.swift
@@ -43,8 +43,6 @@ extension Row {
 }
 
 class RowTests: XCTestCase {
-
-
     public func test_get_value() throws {
         let row = Row(["\"foo\"": 0], ["value"])
         let result = try row.get(SQLite.Expression<String>("foo"))

--- a/Tests/SQLiteTests/Typed/RowTests.swift
+++ b/Tests/SQLiteTests/Typed/RowTests.swift
@@ -1,7 +1,49 @@
 import XCTest
 @testable import SQLite
 
+struct CursorWithStringArray: CursorProtocol {
+	let elements: [Binding?]
+	init(elements: [Binding?]) {
+		self.elements = elements
+	}
+
+	func getValue(_ idx: Int) throws -> Binding? {
+		elements[idx]
+	}
+	func getValue(_ idx: Int) throws -> Double {
+		guard let value = elements[idx] as? Double else {
+			throw QueryError.unexpectedNullValue(name: "column at index \(idx)")
+		}
+		return value
+	}
+	func getValue(_ idx: Int) throws -> Int64 {
+		guard let value = elements[idx] as? Int64 else {
+			throw QueryError.unexpectedNullValue(name: "column at index \(idx)")
+		}
+		return value
+	}
+	func getValue(_ idx: Int) throws -> String {
+		guard let value = elements[idx] as? String else {
+			throw QueryError.unexpectedNullValue(name: "column at index \(idx)")
+		}
+		return value
+	}
+	func getValue(_ idx: Int) throws -> Blob {
+		guard let value = elements[idx] as? Blob else {
+			throw QueryError.unexpectedNullValue(name: "column at index \(idx)")
+		}
+		return value
+	}
+}
+
+extension Row {
+	init(_ columnNames: [String: Int], _ values: [Binding?]) {
+		self.init(columnNames, CursorWithStringArray(elements: values))
+	}
+}
+
 class RowTests: XCTestCase {
+
 
     public func test_get_value() throws {
         let row = Row(["\"foo\"": 0], ["value"])
@@ -32,14 +74,14 @@ class RowTests: XCTestCase {
     }
 
     public func test_get_value_optional_nil() throws {
-        let row = Row(["\"foo\"": 0], [nil])
+		let row = Row(["\"foo\"": 0], [String?.none])
         let result = try row.get(SQLite.Expression<String?>("foo"))
 
         XCTAssertNil(result)
     }
 
     public func test_get_value_optional_nil_subscript() {
-        let row = Row(["\"foo\"": 0], [nil])
+        let row = Row(["\"foo\"": 0], [String?.none])
         let result = row[SQLite.Expression<String?>("foo")]
 
         XCTAssertNil(result)


### PR DESCRIPTION
Although the data stored in SQLite has specified types, these are more for guidance. If an int value is stored as a string, it should be readable as an int. This is the behavior supported by SQLite.

# Changes
- Use LazySequence to delay the creation of Cursor (statement.handle) and the access of Cursor.getValue to match the variable type of Codable.
- Change subscribe of Cursor to a regular method with throws to bypass the compiler error Ambiguous use of 'xxxxx' and simplify the indentation of get throws.