### PR TITLE
Updates swift-toolchain-sqlite

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let deps: [Package.Dependency] = [
-    .github("swiftlang/swift-toolchain-sqlite", exact: "1.0.4")
+    .github("swiftlang/swift-toolchain-sqlite", exact: "1.0.7")
 ]
 
 let targets: [Target] = [


### PR DESCRIPTION
Updates the swift-toolchain-sqlite to 1.0.7

swift-toolchain-sqlite versions prior to 1.0.6 are using a vulnerable SQLite version: https://nvd.nist.gov/vuln/detail/CVE-2025-6965

Fixes #1331 
