### PR TITLE
Add PrivacyInfo.xcprivacy as a resource to fix SPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let target: Target = .target(
                  condition: .when(platforms: applePlatforms, traits: ["SQLCipher"]))
     ],
     exclude: ["Info.plist"],
+    resources: [.copy("PrivacyInfo.xcprivacy")],
     cSettings: [
         .define("SQLITE_HAS_CODEC", .when(platforms: applePlatforms, traits: ["SQLCipher"]))
     ]


### PR DESCRIPTION
## Summary

The privacy manifest (`PrivacyInfo.xcprivacy`) was added in #1234 but not declared in `Package.swift`, causing SPM to emit a warning:

```
'sqlite.swift': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
```

This PR adds the file as a copied resource so the warning is resolved and the privacy manifest is properly included in the bundle.

## Test plan

- [x] `swift build` completes without the "unhandled files" warning
- [x] `PrivacyInfo.xcprivacy` is copied to the bundle during build