### PR TITLE
Add explicit deterministic close support for SQLite connections

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -16,6 +16,7 @@
       - [In-Memory Databases](#in-memory-databases)
       - [URI parameters](#uri-parameters)
       - [Thread-Safety](#thread-safety)
+      - [Closing a Connection](#closing-a-connection)
   - [Building Type-Safe SQL](#building-type-safe-sql)
     - [Expressions](#expressions)
     - [Compound Expressions](#compound-expressions)
@@ -489,6 +490,22 @@ db.busyHandler({ tries in
 > _Note:_ The default timeout is 0, so if you see `database is locked`
 > errors, you may be trying to access the same database simultaneously from
 > multiple connections.
+
+#### Closing a Connection
+
+Call `close()` when you need the database connection closed before the
+`Connection` goes out of scope—for example, before removing a temporary
+database file from disk.
+
+```swift
+try db.close()
+```
+
+Release prepared statements, BLOB handles, and [backup](#online-database-backup)
+objects before closing; otherwise `close()` may throw.
+
+> _Note:_ On iOS, call `close()` (and handle any errors) before deleting temporary
+> database files to avoid filesystem warnings.
 
 
 ## Building Type-Safe SQL

--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -161,7 +161,7 @@ public final class Connection {
     }
 
     deinit {
-        sqlite3_close(handle)
+        try? close()
     }
 
     // MARK: -
@@ -184,6 +184,26 @@ public final class Connection {
     /// database via this connection.
     public var totalChanges: Int {
         Int(sqlite3_total_changes(handle))
+    }
+
+    /// Closes the database connection immediately.
+    ///
+    /// Callers should release or exhaust prepared statements, BLOB handles, and backup operations before closing. If
+    /// SQLite reports that the connection is still busy, this method throws and keeps the connection handle open.
+    public func close() throws {
+        try sync {
+            guard let handle = _handle else {
+                return
+            }
+
+            let resultCode = sqlite3_close(handle)
+            if resultCode == SQLITE_OK {
+                _handle = nil
+                return
+            }
+
+            try check(resultCode)
+        }
     }
 
     /// Whether or not the database will return extended error codes when errors are handled.

--- a/Tests/SQLiteTests/Core/ConnectionTests.swift
+++ b/Tests/SQLiteTests/Core/ConnectionTests.swift
@@ -71,6 +71,33 @@ class ConnectionTests: SQLiteTestCase {
         XCTAssertTrue(db.readonly)
     }
 
+    func test_close_closesConnectionAndIsIdempotent() throws {
+        let db = try Connection()
+
+        try db.close()
+        try db.close()
+    }
+
+    func test_close_whenPreparedStatementIsActiveThrowsBusyAndCanBeRetried() throws {
+        let db = try Connection()
+        var statement: Statement? = try db.prepare("SELECT 1")
+
+        try withExtendedLifetime(statement) {
+            XCTAssertThrowsError(try db.close()) { error in
+                if case SQLite.Result.error(_, let code, _) = error {
+                    XCTAssertEqual(SQLITE_BUSY, code)
+                } else {
+                    XCTFail("unexpected error: \(error)")
+                }
+            }
+        }
+
+        XCTAssertEqual(1, try db.scalar("SELECT 1") as? Int64)
+
+        statement = nil
+        try db.close()
+    }
+
     func test_changes_returnsZeroOnNewConnections() {
         XCTAssertEqual(0, db.changes)
     }


### PR DESCRIPTION
This PR adds an explicit `Connection.close()` API so callers can deterministically close a SQLite database connection before releasing or deleting the underlying database file.

**Motivation**

Some applications need to manage short-lived SQLite database files explicitly. In those cases, relying only on `Connection.deinit` can make file lifetime difficult to coordinate with external cleanup.

This is especially important when a connection may still have active SQLite resources, such as prepared statements. SQLite’s `sqlite3_close()` returns `SQLITE_BUSY` in that case and keeps the connection open. Without an explicit close API, callers cannot observe that failure or retry the close after releasing the remaining resources.

**Solution**

The new `Connection.close()` method:

- Calls `sqlite3_close()` synchronously on the connection queue.
- Sets the internal handle to `nil` only when SQLite reports `SQLITE_OK`.
- Throws the SQLite error when close fails, preserving the live handle so callers can continue using the connection or retry closing it later.
- Is idempotent when called after a successful close.
- Is also used from `deinit`, preserving the previous automatic cleanup behavior.

**Tests**

Added regression coverage for the new behavior:

- Verifies that `close()` succeeds and is idempotent.
- Verifies that `close()` throws `SQLITE_BUSY` while a prepared statement is still active.
- Verifies that the connection remains usable after a failed close attempt.
- Verifies that `close()` succeeds after the active statement is released.