### PR TITLE
Release savepoints after rollback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         brew update
         brew install tuist
         cd Tests/Tuist/SQLite-Test
+        swift package --package-path Tuist resolve
         tuist install
         # tuist test
   build-linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,11 +71,12 @@ jobs:
         VALIDATOR_SUBSPEC: SQLCipher
       run: ./run-tests.sh
     - name: "Run tests (tuist)"
+      env:
+        TUIST_USE_SWIFTERPM: '0'
       run: |
         brew update
         brew install tuist
         cd Tests/Tuist/SQLite-Test
-        swift package --package-path Tuist resolve
         tuist install
         # tuist test
   build-linux:

--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -438,23 +438,6 @@ public final class Connection {
         )
     }
 
-    fileprivate func transaction(_ begin: String, _ block: () throws -> Void, _ commit: String,
-                                 or rollback: String, followedBy cleanup: String? = nil) throws {
-        return try sync {
-            try self.run(begin)
-            do {
-                try block()
-                try self.run(commit)
-            } catch {
-                try self.run(rollback)
-                if let cleanup {
-                    try self.run(cleanup)
-                }
-                throw error
-            }
-        }
-    }
-
     /// Interrupts any long-running queries.
     public func interrupt() {
         sqlite3_interrupt(handle)
@@ -771,6 +754,27 @@ public final class Connection {
     fileprivate static let queueKey = DispatchSpecificKey<Int>()
 
     fileprivate lazy var queueContext: Int = unsafeBitCast(self, to: Int.self)
+
+}
+
+extension Connection {
+
+    fileprivate func transaction(_ begin: String, _ block: () throws -> Void, _ commit: String,
+                                 or rollback: String, followedBy cleanup: String? = nil) throws {
+        return try sync {
+            try self.run(begin)
+            do {
+                try block()
+                try self.run(commit)
+            } catch {
+                try self.run(rollback)
+                if let cleanup {
+                    try self.run(cleanup)
+                }
+                throw error
+            }
+        }
+    }
 
 }
 

--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -429,10 +429,17 @@ public final class Connection {
         let name = name.quote("'")
         let savepoint = "SAVEPOINT \(name)"
 
-        try transaction(savepoint, block, "RELEASE \(savepoint)", or: "ROLLBACK TO \(savepoint)")
+        try transaction(
+            savepoint,
+            block,
+            "RELEASE \(savepoint)",
+            or: "ROLLBACK TO \(savepoint)",
+            followedBy: "RELEASE \(savepoint)"
+        )
     }
 
-    fileprivate func transaction(_ begin: String, _ block: () throws -> Void, _ commit: String, or rollback: String) throws {
+    fileprivate func transaction(_ begin: String, _ block: () throws -> Void, _ commit: String,
+                                 or rollback: String, followedBy cleanup: String? = nil) throws {
         return try sync {
             try self.run(begin)
             do {
@@ -440,6 +447,9 @@ public final class Connection {
                 try self.run(commit)
             } catch {
                 try self.run(rollback)
+                if let cleanup {
+                    try self.run(cleanup)
+                }
                 throw error
             }
         }

--- a/Tests/SQLiteTests/Core/ConnectionTests.swift
+++ b/Tests/SQLiteTests/Core/ConnectionTests.swift
@@ -315,8 +315,27 @@ class ConnectionTests: SQLiteTestCase {
         assertSQL("INSERT INTO users (email) VALUES ('alice@example.com')", 2)
         assertSQL("ROLLBACK TO SAVEPOINT '2'")
         assertSQL("ROLLBACK TO SAVEPOINT '1'")
-        assertSQL("RELEASE SAVEPOINT '2'", 0)
-        assertSQL("RELEASE SAVEPOINT '1'", 0)
+        assertSQL("RELEASE SAVEPOINT '2'")
+        assertSQL("RELEASE SAVEPOINT '1'")
+    }
+
+    func test_savepoint_releasesAfterRollback() throws {
+        let rollbackError = NSError(domain: "com.stephencelis.SQLiteTests", code: 1, userInfo: nil)
+
+        XCTAssertThrowsError(try db.savepoint("1") {
+            try db.run("INSERT INTO users (email) VALUES (?)", "alice@example.com")
+            throw rollbackError
+        }) { error in
+            let error = error as NSError
+            XCTAssertEqual(rollbackError.domain, error.domain)
+            XCTAssertEqual(rollbackError.code, error.code)
+        }
+
+        XCTAssertEqual(0, try db.scalar(users.count))
+        try db.transaction {
+            try db.run("INSERT INTO users (email) VALUES (?)", "alice@example.com")
+        }
+        XCTAssertEqual(1, try db.scalar(users.count))
     }
 
     func test_updateHook_setsUpdateHook_withInsert() throws {


### PR DESCRIPTION
## Summary

- release a savepoint after rolling it back
- keep rollback and release as separate SQLite statements
- cover nested cleanup and successful transaction reuse after a rollback

## Root cause

`ROLLBACK TO SAVEPOINT` rewinds database changes but leaves the savepoint active. The connection therefore remained inside a transaction after a throwing outermost `savepoint` block, causing the next transaction to fail with `cannot start a transaction within a transaction`.

## Impact

Failed savepoint blocks now leave the connection ready for subsequent transactions. Normal transaction and successful savepoint behavior are unchanged.

## Validation

- `git diff --check`
- targeted SQLite state-transition reproduction for nested rollback/release cleanup and subsequent transaction reuse
