### PR TITLE
Exclude PrivacyInfo.xcprivacy resource on Android

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,15 @@
 import PackageDescription
 let applePlatforms: [PackageDescription.Platform] = [.iOS, .macOS, .watchOS, .tvOS, .visionOS]
 
+// Package.swift always compiles for the host, so it can't see the build
+// destination directly — an environment variable (matching the convention
+// used by swift-android-native's own `TARGET_OS_ANDROID` check) is the only
+// way to detect an Android cross-compile here. `PrivacyInfo.xcprivacy` is
+// only meaningful for the Apple App Store; declaring it as a resource makes
+// SwiftPM generate a `Bundle.module` accessor that requires linking all of
+// Foundation on Android, so it's excluded there.
+let isAndroid = Context.environment["TARGET_OS_ANDROID"] ?? "0" != "0"
+
 let target: Target = .target(
     name: "SQLite",
     dependencies: [
@@ -12,8 +21,8 @@ let target: Target = .target(
                  package: "SQLCipher.swift",
                  condition: .when(platforms: applePlatforms, traits: ["SQLCipher"]))
     ],
-    exclude: ["Info.plist"],
-    resources: [.copy("PrivacyInfo.xcprivacy")],
+    exclude: isAndroid ? ["Info.plist", "PrivacyInfo.xcprivacy"] : ["Info.plist"],
+    resources: isAndroid ? [] : [.copy("PrivacyInfo.xcprivacy")],
     cSettings: [
         .define("SQLITE_HAS_CODEC", .when(platforms: applePlatforms, traits: ["SQLCipher"]))
     ]


### PR DESCRIPTION
## Summary
- Declaring `resources: [.copy("PrivacyInfo.xcprivacy")]` on the `SQLite` target makes SwiftPM auto-generate a `resource_bundle_accessor.swift` file with `Bundle.module`, which unconditionally imports Foundation and calls `Bundle.main`/`Bundle(path:)`.
- On the Android Swift SDK, that pulls in `libFoundation.so` — and, since it has its own unconditional dependency on `libFoundationInternationalization.so` + ICU there, all three — for consumers who otherwise only need `FoundationEssentials`.
- `PrivacyInfo.xcprivacy` only has meaning for the Apple App Store, so this excludes it from the target's resources when a `TARGET_OS_ANDROID` environment variable is set, following the same convention [swift-android-native](https://github.com/swift-android-sdk/swift-android-native) uses to detect an Android cross-compile — `Package.swift` always evaluates on the host, so it has no direct way to see the actual build destination.
- No effect on existing consumers: the variable is unset by default, so `PrivacyInfo.xcprivacy` continues to ship exactly as before everywhere else.

## Test plan
- [x] `swift package dump-package` — without the env var, `resources` still includes `PrivacyInfo.xcprivacy`
- [x] `TARGET_OS_ANDROID=1 swift package dump-package` — `resources` is empty and `PrivacyInfo.xcprivacy` moves to `exclude`
- [x] Cross-compiled a downstream Android app against this branch and confirmed via `readelf -d`/`nm` that `Bundle.main`/`Bundle(path:)` no longer appear as undefined symbols